### PR TITLE
Add new item model

### DIFF
--- a/src/main/java/seedu/address/newmodel/Inventory.java
+++ b/src/main/java/seedu/address/newmodel/Inventory.java
@@ -1,0 +1,120 @@
+package seedu.address.newmodel;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import javafx.collections.ObservableList;
+import seedu.address.newmodel.item.Item;
+import seedu.address.newmodel.item.UniqueItemList;
+
+/**
+ * Wraps all data at the inventory level
+ * Duplicates are not allowed (by .isSameItem comparison)
+ */
+public class Inventory implements ReadOnlyInventory {
+
+    private final UniqueItemList items;
+
+    /*
+     * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
+     * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
+     *
+     * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
+     *   among constructors.
+     */
+    {
+        items = new UniqueItemList();
+    }
+
+    public Inventory() {}
+
+    /**
+     * Creates an Inventory using the Items in the {@code toBeCopied}
+     */
+    public Inventory(ReadOnlyInventory toBeCopied) {
+        this();
+        resetData(toBeCopied);
+    }
+
+    //// list overwrite operations
+
+    /**
+     * Replaces the contents of the item list with {@code items}.
+     * {@code items} must not contain duplicate items.
+     */
+    public void setItems(List<Item> items) {
+        this.items.setItems(items);
+    }
+
+    /**
+     * Resets the existing data of this {@code Inventory} with {@code newData}.
+     */
+    public void resetData(ReadOnlyInventory newData) {
+        requireNonNull(newData);
+
+        setItems(newData.getItemList());
+    }
+
+    //// item-level operations
+
+    /**
+     * Returns true if an item with the same id as {@code item} that exists in the inventory.
+     */
+    public boolean hasItem(Item item) {
+        requireNonNull(item);
+        return items.contains(item);
+    }
+
+    /**
+     * Adds an item to the inventory.
+     * If the item already exists in the inventory, increment its count.
+     */
+    public void addItem(Item newItem) {
+        items.add(newItem);
+    }
+
+    /**
+     * Replaces the given item {@code target} in the list with {@code editedItem}.
+     * {@code target} must exist in the inventory.
+     * The item identity of {@code editedItem} must not be the same as another existing item in the inventory.
+     */
+    public void setItem(Item target, Item editedItem) {
+        requireNonNull(editedItem);
+
+        items.setItem(target, editedItem);
+    }
+
+    /**
+     * Removes {@code key} from this {@code Inventory}.
+     * {@code key} must exist in the inventory.
+     */
+    public void removeItem(Item key) {
+        items.remove(key);
+    }
+
+    //// util methods
+
+    @Override
+    public String toString() {
+        return items.asUnmodifiableObservableList().size() + " items";
+        // TODO: refine later
+    }
+
+    @Override
+    public ObservableList<Item> getItemList() {
+        return items.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Inventory // instanceof handles nulls
+                && items.equals(((Inventory) other).items));
+    }
+
+    @Override
+    public int hashCode() {
+        return items.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/newmodel/Model.java
+++ b/src/main/java/seedu/address/newmodel/Model.java
@@ -1,0 +1,88 @@
+package seedu.address.newmodel;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.newmodel.ReadOnlyInventory;
+import seedu.address.newmodel.item.Item;
+
+/**
+ * The API of the Model component.
+ */
+public interface Model {
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<Item> PREDICATE_SHOW_ALL_ITEMS = unused -> true;
+
+    /**
+     * Replaces user prefs data with the data in {@code userPrefs}.
+     */
+    void setUserPrefs(ReadOnlyUserPrefs userPrefs);
+
+    /**
+     * Returns the user prefs.
+     */
+    ReadOnlyUserPrefs getUserPrefs();
+
+    /**
+     * Returns the user prefs' GUI settings.
+     */
+    GuiSettings getGuiSettings();
+
+    /**
+     * Sets the user prefs' GUI settings.
+     */
+    void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Returns the user prefs' address book file path.
+     */
+    Path getInventoryFilePath();
+
+    /**
+     * Sets the user prefs' address book file path.
+     */
+    void setInventoryFilePath(Path addressBookFilePath);
+
+    /**
+     * Replaces inventory data with the data in {@code inventory}.
+     */
+    void setInventory(ReadOnlyInventory inventory);
+
+    /** Returns the Inventory */
+    ReadOnlyInventory getInventory();
+
+    /**
+     * Returns true if a item with the same identity as {@code item} exists in the inventory.
+     */
+    boolean hasItem(Item item);
+
+    /**
+     * Deletes the given item.
+     * The item must exist in the inventory.
+     */
+    void deleteItem(Item target);
+
+    /**
+     * Adds the given item.
+     * If {@code item} must not already exist in the address book, increment its count accordingly.
+     */
+    void addItem(Item item);
+
+    /**
+     * Replaces the given item {@code target} with {@code editedItem}.
+     * {@code target} must exist in the inventory.
+     * The item identity of {@code editedItem} must not be the same as another existing item in the inventory.
+     */
+    void setItem(Item target, Item editedItem);
+
+    /** Returns an unmodifiable view of the filtered item list */
+    ObservableList<Item> getFilteredItemList();
+
+    /**
+     * Updates the filter of the filtered item list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredItemList(Predicate<Item> predicate);
+}

--- a/src/main/java/seedu/address/newmodel/Model.java
+++ b/src/main/java/seedu/address/newmodel/Model.java
@@ -5,7 +5,6 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.newmodel.ReadOnlyInventory;
 import seedu.address.newmodel.item.Item;
 
 /**

--- a/src/main/java/seedu/address/newmodel/ModelManager.java
+++ b/src/main/java/seedu/address/newmodel/ModelManager.java
@@ -11,7 +11,6 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.newmodel.Inventory;
 import seedu.address.newmodel.item.Item;
 
 /**

--- a/src/main/java/seedu/address/newmodel/ModelManager.java
+++ b/src/main/java/seedu/address/newmodel/ModelManager.java
@@ -1,0 +1,152 @@
+package seedu.address.newmodel;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.newmodel.Inventory;
+import seedu.address.newmodel.item.Item;
+
+/**
+ * Represents the in-memory model of the address book data.
+ */
+public class ModelManager implements Model {
+    private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
+
+    private final Inventory inventory;
+    private final UserPrefs userPrefs;
+    private final FilteredList<Item> filteredItems;
+
+    /**
+     * Initializes a ModelManager with the given addressBook and userPrefs.
+     */
+    public ModelManager(ReadOnlyInventory inventory, ReadOnlyUserPrefs userPrefs) {
+        super();
+        requireAllNonNull(inventory, userPrefs);
+
+        logger.fine("Initializing with address book: " + inventory + " and user prefs " + userPrefs);
+
+        this.inventory = new Inventory(inventory);
+        this.userPrefs = new UserPrefs(userPrefs);
+        filteredItems = new FilteredList<>(this.inventory.getItemList());
+    }
+
+    public ModelManager() {
+        this(new Inventory(), new UserPrefs());
+    }
+
+    //=========== UserPrefs ==================================================================================
+
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        requireNonNull(userPrefs);
+        this.userPrefs.resetData(userPrefs);
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        return userPrefs;
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        return userPrefs.getGuiSettings();
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        requireNonNull(guiSettings);
+        userPrefs.setGuiSettings(guiSettings);
+    }
+
+    @Override
+    public Path getInventoryFilePath() {
+        return userPrefs.getInventoryFilePath();
+    }
+
+    @Override
+    public void setInventoryFilePath(Path inventoryFilePath) {
+        requireNonNull(inventoryFilePath);
+        userPrefs.setInventoryFilePath(inventoryFilePath);
+    }
+
+    //=========== AddressBook ================================================================================
+
+    @Override
+    public void setInventory(ReadOnlyInventory inventory) {
+        this.inventory.resetData(inventory);
+    }
+
+    @Override
+    public ReadOnlyInventory getInventory() {
+        return inventory;
+    }
+
+    @Override
+    public boolean hasItem(Item item) {
+        requireNonNull(item);
+        return inventory.hasItem(item);
+    }
+
+    @Override
+    public void deleteItem(Item target) {
+        inventory.removeItem(target);
+    }
+
+    @Override
+    public void addItem(Item item) {
+        inventory.addItem(item);
+        updateFilteredItemList(PREDICATE_SHOW_ALL_ITEMS);
+    }
+
+    @Override
+    public void setItem(Item target, Item editedItem) {
+        requireAllNonNull(target, editedItem);
+
+        inventory.setItem(target, editedItem);
+    }
+
+    //=========== Filtered Item List Accessors =============================================================
+
+    /**
+     * Returns an unmodifiable view of the list of {@code Item} backed by the internal list of
+     * {@code versionedInventory}
+     */
+    @Override
+    public ObservableList<Item> getFilteredItemList() {
+        return filteredItems;
+    }
+
+    @Override
+    public void updateFilteredItemList(Predicate<Item> predicate) {
+        requireNonNull(predicate);
+        filteredItems.setPredicate(predicate);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        // short circuit if same object
+        if (obj == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(obj instanceof ModelManager)) {
+            return false;
+        }
+
+        // state check
+        ModelManager other = (ModelManager) obj;
+        return inventory.equals(other.inventory)
+                && userPrefs.equals(other.userPrefs)
+                && filteredItems.equals(other.filteredItems);
+    }
+
+}

--- a/src/main/java/seedu/address/newmodel/ReadOnlyInventory.java
+++ b/src/main/java/seedu/address/newmodel/ReadOnlyInventory.java
@@ -1,0 +1,17 @@
+package seedu.address.newmodel;
+
+import javafx.collections.ObservableList;
+import seedu.address.newmodel.item.Item;
+
+/**
+ * Unmodifiable view of an address book
+ */
+public interface ReadOnlyInventory {
+
+    /**
+     * Returns an unmodifiable view of the items list.
+     * This list will not contain any duplicate items.
+     */
+    ObservableList<Item> getItemList();
+
+}

--- a/src/main/java/seedu/address/newmodel/ReadOnlyUserPrefs.java
+++ b/src/main/java/seedu/address/newmodel/ReadOnlyUserPrefs.java
@@ -1,0 +1,16 @@
+package seedu.address.newmodel;
+
+import java.nio.file.Path;
+
+import seedu.address.commons.core.GuiSettings;
+
+/**
+ * Unmodifiable view of user prefs.
+ */
+public interface ReadOnlyUserPrefs {
+
+    GuiSettings getGuiSettings();
+
+    Path getInventoryFilePath();
+
+}

--- a/src/main/java/seedu/address/newmodel/UserPrefs.java
+++ b/src/main/java/seedu/address/newmodel/UserPrefs.java
@@ -1,0 +1,87 @@
+package seedu.address.newmodel;
+
+import static java.util.Objects.requireNonNull;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+import seedu.address.commons.core.GuiSettings;
+
+/**
+ * Represents User's preferences.
+ */
+public class UserPrefs implements ReadOnlyUserPrefs {
+
+    private GuiSettings guiSettings = new GuiSettings();
+    private Path inventoryFilePath = Paths.get("data" , "inventory.json");
+
+    /**
+     * Creates a {@code UserPrefs} with default values.
+     */
+    public UserPrefs() {}
+
+    /**
+     * Creates a {@code UserPrefs} with the prefs in {@code userPrefs}.
+     */
+    public UserPrefs(ReadOnlyUserPrefs userPrefs) {
+        this();
+        resetData(userPrefs);
+    }
+
+    /**
+     * Resets the existing data of this {@code UserPrefs} with {@code newUserPrefs}.
+     */
+    public void resetData(ReadOnlyUserPrefs newUserPrefs) {
+        requireNonNull(newUserPrefs);
+        setGuiSettings(newUserPrefs.getGuiSettings());
+        setInventoryFilePath(newUserPrefs.getInventoryFilePath());
+    }
+
+    public GuiSettings getGuiSettings() {
+        return guiSettings;
+    }
+
+    public void setGuiSettings(GuiSettings guiSettings) {
+        requireNonNull(guiSettings);
+        this.guiSettings = guiSettings;
+    }
+
+    public Path getInventoryFilePath() {
+        return inventoryFilePath;
+    }
+
+    public void setInventoryFilePath(Path inventoryFilePath) {
+        requireNonNull(inventoryFilePath);
+        this.inventoryFilePath = inventoryFilePath;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof UserPrefs)) { //this handles null as well.
+            return false;
+        }
+
+        UserPrefs o = (UserPrefs) other;
+
+        return guiSettings.equals(o.guiSettings)
+                && inventoryFilePath.equals(o.inventoryFilePath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(guiSettings, inventoryFilePath);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Gui Settings : " + guiSettings);
+        sb.append("\nLocal data file location : " + inventoryFilePath);
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/seedu/address/newmodel/item/Item.java
+++ b/src/main/java/seedu/address/newmodel/item/Item.java
@@ -7,7 +7,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
-import seedu.address.model.tag.Tag;
+import seedu.address.newmodel.tag.Tag;
 
 /**
  * Represents an item in the inventory.

--- a/src/main/java/seedu/address/newmodel/item/Item.java
+++ b/src/main/java/seedu/address/newmodel/item/Item.java
@@ -1,0 +1,105 @@
+package seedu.address.newmodel.item;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import seedu.address.model.tag.Tag;
+
+/**
+ * Represents an item in the inventory.
+ * Guarantees: details are present and not null, field values are validated, immutable.
+ */
+public class Item {
+
+    // Identity fields
+    private final Name name;
+    private final String id;
+
+    // Data fields
+    private final Set<Tag> tags = new HashSet<>();
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Item(Name name, String id, Set<Tag> tags) {
+        requireAllNonNull(name, id, tags);
+        this.name = name;
+        this.id = id;
+        this.tags.addAll(tags);
+    }
+
+    public Name getName() {
+        return name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public Set<Tag> getTags() {
+        return Collections.unmodifiableSet(tags);
+    }
+
+    /**
+     * Returns true if both items have the same name or id.
+     * This defines a weaker notion of equality between two items.
+     */
+    public boolean isSameItem(Item otherItem) {
+        if (otherItem == this) {
+            return true;
+        }
+
+        return otherItem != null
+                && (otherItem.getName().equals(getName()) || (otherItem.getId().equals(getId())));
+    }
+
+    /**
+     * Returns true if both items have the same identity and data fields.
+     * This defines a stronger notion of equality between two items.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Item)) {
+            return false;
+        }
+
+        Item otherItem = (Item) other;
+        return otherItem.getName().equals(getName())
+                && otherItem.getId().equals(getId())
+                && otherItem.getTags().equals(getTags());
+    }
+
+    @Override
+    public int hashCode() {
+        // use this method for custom fields hashing instead of implementing your own
+        return Objects.hash(name, id, tags);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(getName())
+                .append("; id: ")
+                .append(getId());
+
+        Set<Tag> tags = getTags();
+        if (!tags.isEmpty()) {
+            builder.append("; Tags: ");
+            tags.forEach(builder::append);
+        }
+        return builder.toString();
+    }
+
+}

--- a/src/main/java/seedu/address/newmodel/item/Name.java
+++ b/src/main/java/seedu/address/newmodel/item/Name.java
@@ -1,0 +1,59 @@
+package seedu.address.newmodel.item;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Item's name in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
+ */
+public class Name {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    public final String fullName;
+
+    /**
+     * Constructs a {@code Name}.
+     *
+     * @param name A valid name.
+     */
+    public Name(String name) {
+        requireNonNull(name);
+        checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
+        fullName = name;
+    }
+
+    /**
+     * Returns true if a given string is a valid name.
+     */
+    public static boolean isValidName(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+
+    @Override
+    public String toString() {
+        return fullName;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Name // instanceof handles nulls
+                && fullName.equals(((Name) other).fullName)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return fullName.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/newmodel/item/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/newmodel/item/NameContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.newmodel.item;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Item}'s {@code Name} matches any of the keywords given.
+ */
+public class NameContainsKeywordsPredicate implements Predicate<Item> {
+    private final List<String> keywords;
+
+    public NameContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Item item) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(item.getName().fullName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof NameContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((NameContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/newmodel/item/UniqueItemList.java
+++ b/src/main/java/seedu/address/newmodel/item/UniqueItemList.java
@@ -1,0 +1,137 @@
+package seedu.address.newmodel.item;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.newmodel.item.exceptions.DuplicateItemException;
+import seedu.address.newmodel.item.exceptions.ItemNotFoundException;
+
+/**
+ * A list of items that enforces uniqueness between its elements and does not allow nulls.
+ * An item is considered unique by comparing using {@code Item#isSameItem(Item)}. As such, adding and updating of
+ * items uses Item#Item(Item) for equality so as to ensure that the item being added or updated is
+ * unique in terms of identity in the UniqueItemList. However, the removal of a item uses Item#equals(Object) so
+ * as to ensure that the item with exactly the same fields will be removed.
+ *
+ * Supports a minimal set of list operations.
+ *
+ * @see Item#isSameItem(Item)
+ */
+public class UniqueItemList implements Iterable<Item> {
+
+    private final ObservableList<Item> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Item> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an equivalent item as the given argument.
+     */
+    public boolean contains(Item toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameItem);
+    }
+
+    /**
+     * Adds an item to the list.
+     * The item must not already exist in the list.
+     */
+    public void add(Item toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicateItemException();
+        }
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the item {@code target} in the list with {@code editedItem}.
+     * {@code target} must exist in the list.
+     * The item identity of {@code editedItem} must not be the same as another existing item in the list.
+     */
+    public void setItem(Item target, Item editedItem) {
+        requireAllNonNull(target, editedItem);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new ItemNotFoundException();
+        }
+
+        if (!target.isSameItem(editedItem) && contains(editedItem)) {
+            throw new DuplicateItemException();
+        }
+
+        internalList.set(index, editedItem);
+    }
+
+    /**
+     * Removes the equivalent item from the list.
+     * The item must exist in the list.
+     */
+    public void remove(Item toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new ItemNotFoundException();
+        }
+    }
+
+    public void setItems(UniqueItemList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the contents of this list with {@code items}.
+     * {@code items} must not contain duplicate items.
+     */
+    public void setItems(List<Item> items) {
+        requireAllNonNull(items);
+        if (!itemsAreUnique(items)) {
+            throw new DuplicateItemException();
+        }
+
+        internalList.setAll(items);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Item> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<Item> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UniqueItemList // instanceof handles nulls
+                        && internalList.equals(((UniqueItemList) other).internalList));
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+    /**
+     * Returns true if {@code items} contains only unique items.
+     */
+    private boolean itemsAreUnique(List<Item> items) {
+        for (int i = 0; i < items.size() - 1; i++) {
+            for (int j = i + 1; j < items.size(); j++) {
+                if (items.get(i).isSameItem(items.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/seedu/address/newmodel/item/exceptions/DuplicateItemException.java
+++ b/src/main/java/seedu/address/newmodel/item/exceptions/DuplicateItemException.java
@@ -1,0 +1,11 @@
+package seedu.address.newmodel.item.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Items (Items are considered duplicates if they have the same
+ * id).
+ */
+public class DuplicateItemException extends RuntimeException {
+    public DuplicateItemException() {
+        super("Operation would result in duplicate items");
+    }
+}

--- a/src/main/java/seedu/address/newmodel/item/exceptions/ItemNotFoundException.java
+++ b/src/main/java/seedu/address/newmodel/item/exceptions/ItemNotFoundException.java
@@ -1,0 +1,6 @@
+package seedu.address.newmodel.item.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified item.
+ */
+public class ItemNotFoundException extends RuntimeException {}

--- a/src/main/java/seedu/address/newmodel/tag/Tag.java
+++ b/src/main/java/seedu/address/newmodel/tag/Tag.java
@@ -1,0 +1,54 @@
+package seedu.address.newmodel.tag;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Tag in the Inventory.
+ * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
+ */
+public class Tag {
+
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+
+    public final String tagName;
+
+    /**
+     * Constructs a {@code Tag}.
+     *
+     * @param tagName A valid tag name.
+     */
+    public Tag(String tagName) {
+        requireNonNull(tagName);
+        checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
+        this.tagName = tagName;
+    }
+
+    /**
+     * Returns true if a given string is a valid tag name.
+     */
+    public static boolean isValidTagName(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Tag // instanceof handles nulls
+                && tagName.equals(((Tag) other).tagName)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return tagName.hashCode();
+    }
+
+    /**
+     * Format state as text for viewing.
+     */
+    public String toString() {
+        return '[' + tagName + ']';
+    }
+
+}

--- a/src/main/java/seedu/address/newmodel/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/newmodel/util/SampleDataUtil.java
@@ -6,9 +6,9 @@ import java.util.stream.Collectors;
 
 import seedu.address.newmodel.Inventory;
 import seedu.address.newmodel.ReadOnlyInventory;
-import seedu.address.newmodel.item.Name;
 import seedu.address.newmodel.item.Item;
-import seedu.address.model.tag.Tag;
+import seedu.address.newmodel.item.Name;
+import seedu.address.newmodel.tag.Tag;
 
 /**
  * Contains utility methods for populating {@code AddressBook} with sample data.

--- a/src/main/java/seedu/address/newmodel/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/newmodel/util/SampleDataUtil.java
@@ -1,0 +1,51 @@
+package seedu.address.newmodel.util;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import seedu.address.newmodel.Inventory;
+import seedu.address.newmodel.ReadOnlyInventory;
+import seedu.address.newmodel.item.Name;
+import seedu.address.newmodel.item.Item;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Contains utility methods for populating {@code AddressBook} with sample data.
+ */
+public class SampleDataUtil {
+    public static Item[] getSampleItems() {
+        return new Item[] {
+            new Item(new Name("Oatmeal Cookie"), "#140121",
+                getTagSet("baked")),
+            new Item(new Name("Banana Muffin"), "#201928",
+                    getTagSet("baked")),
+            new Item(new Name("Pecan Pie"), "#178522",
+                    getTagSet("baked")),
+            new Item(new Name("Oreo Cheesecake"), "#109128",
+                    getTagSet("desert")),
+            new Item(new Name("Strawberry Shortcake"), "#091287",
+                    getTagSet("desert")),
+            new Item(new Name("Cold Brew Coffee"), "#001858",
+                    getTagSet("beverage")),
+        };
+    }
+
+    public static ReadOnlyInventory getSampleItemList() {
+        Inventory sampleInventory = new Inventory();
+        for (Item sampleItem : getSampleItems()) {
+            sampleInventory.addItem(sampleItem);
+        }
+        return sampleInventory;
+    }
+
+    /**
+     * Returns a tag set containing the list of strings given.
+     */
+    public static Set<Tag> getTagSet(String... strings) {
+        return Arrays.stream(strings)
+                .map(Tag::new)
+                .collect(Collectors.toSet());
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -26,6 +26,13 @@ import seedu.address.testutil.EditPersonDescriptorBuilder;
  */
 public class CommandTestUtil {
 
+    public static final String VALID_NAME_BAGEL = "Bagel";
+    public static final String VALID_NAME_DONUT = "Donut";
+    public static final String VALID_ID_BAGEL = "B1354";
+    public static final String VALID_TAG_BAKED = "baked";
+    public static final String VALID_TAG_POPULAR = "popular";
+
+
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";

--- a/src/test/java/seedu/address/newmodel/InventoryTest.java
+++ b/src/test/java/seedu/address/newmodel/InventoryTest.java
@@ -1,0 +1,99 @@
+package seedu.address.newmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_POPULAR;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalItems.APPLE_PIE;
+import static seedu.address.testutil.TypicalItems.getTypicalInventory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.newmodel.item.Item;
+import seedu.address.newmodel.item.exceptions.DuplicateItemException;
+import seedu.address.testutil.ItemBuilder;
+
+public class InventoryTest {
+
+    private final Inventory inventory = new Inventory();
+
+    @Test
+    public void constructor() {
+        assertEquals(Collections.emptyList(), inventory.getItemList());
+    }
+
+    @Test
+    public void resetData_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> inventory.resetData(null));
+    }
+
+    @Test
+    public void resetData_withValidReadOnlyInventory_replacesData() {
+        Inventory newData = getTypicalInventory();
+        inventory.resetData(newData);
+        assertEquals(newData, inventory);
+    }
+
+    @Test
+    public void resetData_withDuplicatePersons_throwsDuplicatePersonException() {
+        // Two persons with the same identity fields
+        Item editedPie = new ItemBuilder(APPLE_PIE).withTags(VALID_TAG_POPULAR).build();
+        List<Item> newItems = Arrays.asList(APPLE_PIE, editedPie);
+        InventoryStub newData = new InventoryStub(newItems);
+
+        assertThrows(DuplicateItemException.class, () -> inventory.resetData(newData));
+    }
+
+    @Test
+    public void hasItem_nullItem_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> inventory.hasItem(null));
+    }
+
+    @Test
+    public void hasInventory_itemNotInInventory_returnsFalse() {
+        assertFalse(inventory.hasItem(APPLE_PIE));
+    }
+
+    @Test
+    public void hasItem_itemInInventory_returnsTrue() {
+        inventory.addItem(APPLE_PIE);
+        assertTrue(inventory.hasItem(APPLE_PIE));
+    }
+
+    @Test
+    public void hasItem_itemWithSameIdentityFieldsInInventory_returnsTrue() {
+        inventory.addItem(APPLE_PIE);
+        Item editedPie = new ItemBuilder(APPLE_PIE).withTags(VALID_TAG_POPULAR).build();
+        assertTrue(inventory.hasItem(editedPie));
+    }
+
+    @Test
+    public void getPersonList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> inventory.getItemList().remove(0));
+    }
+
+    /**
+     * A stub ReadOnlyInventory whose item list can violate interface constraints.
+     */
+    private static class InventoryStub implements ReadOnlyInventory {
+        private final ObservableList<Item> items = FXCollections.observableArrayList();
+
+        InventoryStub(Collection<Item> items) {
+            this.items.setAll(items);
+        }
+
+        @Override
+        public ObservableList<Item> getItemList() {
+            return items;
+        }
+    }
+
+}

--- a/src/test/java/seedu/address/newmodel/ModelManagerTest.java
+++ b/src/test/java/seedu/address/newmodel/ModelManagerTest.java
@@ -1,0 +1,132 @@
+package seedu.address.newmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.newmodel.Model.PREDICATE_SHOW_ALL_ITEMS;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalItems.APPLE_PIE;
+import static seedu.address.testutil.TypicalItems.BANANA_MUFFIN;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.newmodel.item.NameContainsKeywordsPredicate;
+import seedu.address.testutil.InventoryBuilder;
+
+public class ModelManagerTest {
+
+    private ModelManager modelManager = new ModelManager();
+
+    @Test
+    public void constructor() {
+        assertEquals(new UserPrefs(), modelManager.getUserPrefs());
+        assertEquals(new GuiSettings(), modelManager.getGuiSettings());
+        assertEquals(new Inventory(), new Inventory(modelManager.getInventory()));
+    }
+
+    @Test
+    public void setUserPrefs_nullUserPrefs_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.setUserPrefs(null));
+    }
+
+    @Test
+    public void setUserPrefs_validUserPrefs_copiesUserPrefs() {
+        UserPrefs userPrefs = new UserPrefs();
+        userPrefs.setInventoryFilePath(Paths.get("inventory/file/path"));
+        userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4));
+        modelManager.setUserPrefs(userPrefs);
+        assertEquals(userPrefs, modelManager.getUserPrefs());
+
+        // Modifying userPrefs should not modify modelManager's userPrefs
+        UserPrefs oldUserPrefs = new UserPrefs(userPrefs);
+        userPrefs.setInventoryFilePath(Paths.get("new/inventory/file/path"));
+        assertEquals(oldUserPrefs, modelManager.getUserPrefs());
+    }
+
+    @Test
+    public void setGuiSettings_nullGuiSettings_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.setGuiSettings(null));
+    }
+
+    @Test
+    public void setGuiSettings_validGuiSettings_setsGuiSettings() {
+        GuiSettings guiSettings = new GuiSettings(1, 2, 3, 4);
+        modelManager.setGuiSettings(guiSettings);
+        assertEquals(guiSettings, modelManager.getGuiSettings());
+    }
+
+    @Test
+    public void setInventoryFilePath_nullPath_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.setInventoryFilePath(null));
+    }
+
+    @Test
+    public void setInventoryFilePath_validPath_setsInventoryFilePath() {
+        Path path = Paths.get("inventory/file/path");
+        modelManager.setInventoryFilePath(path);
+        assertEquals(path, modelManager.getInventoryFilePath());
+    }
+
+    @Test
+    public void hasItem_nullItem_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasItem(null));
+    }
+
+    @Test
+    public void hasItem_itemNotInInventory_returnsFalse() {
+        assertFalse(modelManager.hasItem(APPLE_PIE));
+    }
+
+    @Test
+    public void hasItem_itemInInventory_returnsTrue() {
+        modelManager.addItem(APPLE_PIE);
+        assertTrue(modelManager.hasItem(APPLE_PIE));
+    }
+
+    @Test
+    public void getFilteredItemList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredItemList().remove(0));
+    }
+
+    @Test
+    public void equals() {
+        Inventory inventory = new InventoryBuilder().withItem(APPLE_PIE).withItem(BANANA_MUFFIN).build();
+        Inventory differentInventory = new Inventory();
+        UserPrefs userPrefs = new UserPrefs();
+
+        // same values -> returns true
+        modelManager = new ModelManager(inventory, userPrefs);
+        ModelManager modelManagerCopy = new ModelManager(inventory, userPrefs);
+        assertTrue(modelManager.equals(modelManagerCopy));
+
+        // same object -> returns true
+        assertTrue(modelManager.equals(modelManager));
+
+        // null -> returns false
+        assertFalse(modelManager.equals(null));
+
+        // different types -> returns false
+        assertFalse(modelManager.equals(5));
+
+        // different inventory -> returns false
+        assertFalse(modelManager.equals(new ModelManager(differentInventory, userPrefs)));
+
+        // different filteredList -> returns false
+        String[] keywords = APPLE_PIE.getName().fullName.split("\\s+");
+        modelManager.updateFilteredItemList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+        assertFalse(modelManager.equals(new ModelManager(inventory, userPrefs)));
+
+        // resets modelManager to initial state for upcoming tests
+        modelManager.updateFilteredItemList(PREDICATE_SHOW_ALL_ITEMS);
+
+        // different userPrefs -> returns false
+        UserPrefs differentUserPrefs = new UserPrefs();
+        differentUserPrefs.setInventoryFilePath(Paths.get("differentFilePath"));
+        assertFalse(modelManager.equals(new ModelManager(inventory, differentUserPrefs)));
+    }
+}

--- a/src/test/java/seedu/address/newmodel/UserPrefsTest.java
+++ b/src/test/java/seedu/address/newmodel/UserPrefsTest.java
@@ -1,0 +1,21 @@
+package seedu.address.newmodel;
+
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class UserPrefsTest {
+
+    @Test
+    public void setGuiSettings_nullGuiSettings_throwsNullPointerException() {
+        UserPrefs userPref = new UserPrefs();
+        assertThrows(NullPointerException.class, () -> userPref.setGuiSettings(null));
+    }
+
+    @Test
+    public void setInventoryFilePath_nullPath_throwsNullPointerException() {
+        UserPrefs userPrefs = new UserPrefs();
+        assertThrows(NullPointerException.class, () -> userPrefs.setInventoryFilePath(null));
+    }
+
+}

--- a/src/test/java/seedu/address/newmodel/item/ItemTest.java
+++ b/src/test/java/seedu/address/newmodel/item/ItemTest.java
@@ -1,0 +1,83 @@
+package seedu.address.newmodel.item;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_POPULAR;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalItems.APPLE_PIE;
+import static seedu.address.testutil.TypicalItems.BANANA_MUFFIN;
+import static seedu.address.testutil.TypicalItems.BAGEL;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.ItemBuilder;
+
+public class ItemTest {
+
+    @Test
+    public void asObservableList_modifyList_throwsUnsupportedOperationException() {
+        Item item = new ItemBuilder().build();
+        assertThrows(UnsupportedOperationException.class, () -> item.getTags().remove(0));
+    }
+
+    @Test
+    public void isSameItem() {
+        // same object -> returns true
+        assertTrue(APPLE_PIE.isSameItem(APPLE_PIE));
+
+        // null -> returns false
+        assertFalse(APPLE_PIE.isSameItem(null));
+
+        // same name, different id, all other attributes different -> returns true
+        Item editedPie = new ItemBuilder(APPLE_PIE).withId("#123456").build();
+        assertTrue(APPLE_PIE.isSameItem(editedPie));
+
+        // different name, same id, all other attributes different -> returns true
+        editedPie = new ItemBuilder(APPLE_PIE).withName("Cherry Pie").build();
+        assertTrue(APPLE_PIE.isSameItem(editedPie));
+
+        // different name, different id, all other attributes same -> returns false
+        editedPie = new ItemBuilder(APPLE_PIE)
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
+        assertFalse(APPLE_PIE.isSameItem(editedPie));
+
+        // name differs in case, all other attributes same -> returns false
+        Item editedBagel = new ItemBuilder(BAGEL)
+                .withName(VALID_NAME_BAGEL.toUpperCase()).build();
+        assertFalse(BANANA_MUFFIN.isSameItem(editedBagel));
+
+    }
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        Item pieCopy = new ItemBuilder(APPLE_PIE).build();
+        assertTrue(APPLE_PIE.equals(pieCopy));
+
+        // same object -> returns true
+        assertTrue(APPLE_PIE.equals(APPLE_PIE));
+
+        // null -> returns false
+        assertFalse(APPLE_PIE.equals(null));
+
+        // different type -> returns false
+        assertFalse(APPLE_PIE.equals(5));
+
+        // different item -> returns false
+        assertFalse(APPLE_PIE.equals(BANANA_MUFFIN));
+
+        // different name -> returns false
+        Item editedPie = new ItemBuilder(APPLE_PIE).withName(VALID_NAME_BAGEL).build();
+        assertFalse(APPLE_PIE.equals(editedPie));
+
+        // different id -> returns false
+        editedPie = new ItemBuilder(APPLE_PIE).withId(VALID_ID_BAGEL).build();
+        assertFalse(APPLE_PIE.equals(editedPie));
+
+        // different tags -> returns false
+        editedPie = new ItemBuilder(APPLE_PIE).withTags(VALID_TAG_POPULAR).build();
+        assertFalse(APPLE_PIE.equals(editedPie));
+    }
+}

--- a/src/test/java/seedu/address/newmodel/item/ItemTest.java
+++ b/src/test/java/seedu/address/newmodel/item/ItemTest.java
@@ -2,13 +2,13 @@ package seedu.address.newmodel.item;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_POPULAR;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalItems.APPLE_PIE;
-import static seedu.address.testutil.TypicalItems.BANANA_MUFFIN;
 import static seedu.address.testutil.TypicalItems.BAGEL;
+import static seedu.address.testutil.TypicalItems.BANANA_MUFFIN;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/newmodel/item/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/newmodel/item/NameContainsKeywordsPredicateTest.java
@@ -1,0 +1,70 @@
+package seedu.address.newmodel.item;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.ItemBuilder;
+
+public class NameContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
+        NameContainsKeywordsPredicate secondPredicate = new NameContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        NameContainsKeywordsPredicate firstPredicateCopy = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different item -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nameContainsKeywords_returnsTrue() {
+        // One keyword
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Apple"));
+        assertTrue(predicate.test(new ItemBuilder().withName("Apple Pie").build()));
+
+        // Multiple keywords
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Banana", "Pie"));
+        assertTrue(predicate.test(new ItemBuilder().withName("Apple Pie").build()));
+
+        // Mixed-case keywords
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("aPplE", "pIe"));
+        assertTrue(predicate.test(new ItemBuilder().withName("Apple Pie").build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new ItemBuilder().withName("Apple Pie").build()));
+
+        // Non-matching keyword
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Chocochip", "Cookie"));
+        assertFalse(predicate.test(new ItemBuilder().withName("Apple Pie Banana Muffin").build()));
+
+        // Keywords match id and tag, but does not match name
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("#12345", "baked"));
+        assertFalse(predicate.test(new ItemBuilder().withName("Apple Pie").withId("#12345").withTags("baked").build()));
+    }
+}

--- a/src/test/java/seedu/address/newmodel/item/NameTest.java
+++ b/src/test/java/seedu/address/newmodel/item/NameTest.java
@@ -1,0 +1,40 @@
+package seedu.address.newmodel.item;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class NameTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Name(null));
+    }
+
+    @Test
+    public void constructor_invalidName_throwsIllegalArgumentException() {
+        String invalidName = "";
+        assertThrows(IllegalArgumentException.class, () -> new Name(invalidName));
+    }
+
+    @Test
+    public void isValidName() {
+        // null name
+        assertThrows(NullPointerException.class, () -> Name.isValidName(null));
+
+        // invalid name
+        assertFalse(Name.isValidName("")); // empty string
+        assertFalse(Name.isValidName(" ")); // spaces only
+        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
+        assertFalse(Name.isValidName("biscuit*")); // contains non-alphanumeric characters
+
+        // valid name
+        assertTrue(Name.isValidName("butter biscuit")); // alphabets only
+        assertTrue(Name.isValidName("12345")); // numbers only
+        assertTrue(Name.isValidName("100 plus")); // alphanumeric characters
+        assertTrue(Name.isValidName("Butter Biscuit")); // with capital letters
+        assertTrue(Name.isValidName("Butter Butter Butter Butter Butter Biscuit")); // long names
+    }
+}

--- a/src/test/java/seedu/address/newmodel/item/UniqueItemListTest.java
+++ b/src/test/java/seedu/address/newmodel/item/UniqueItemListTest.java
@@ -1,0 +1,168 @@
+package seedu.address.newmodel.item;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_POPULAR;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalItems.APPLE_PIE;
+import static seedu.address.testutil.TypicalItems.BANANA_MUFFIN;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.newmodel.item.exceptions.DuplicateItemException;
+import seedu.address.newmodel.item.exceptions.ItemNotFoundException;
+import seedu.address.testutil.ItemBuilder;
+
+public class UniqueItemListTest {
+
+    private final UniqueItemList uniqueItemList = new UniqueItemList();
+
+    @Test
+    public void contains_nullItem_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueItemList.contains(null));
+    }
+
+    @Test
+    public void contains_itemNotInList_returnsFalse() {
+        assertFalse(uniqueItemList.contains(APPLE_PIE));
+    }
+
+    @Test
+    public void contains_itemInList_returnsTrue() {
+        uniqueItemList.add(APPLE_PIE);
+        assertTrue(uniqueItemList.contains(APPLE_PIE));
+    }
+
+    @Test
+    public void contains_itemWithSameIdentityFieldsInList_returnsTrue() {
+        uniqueItemList.add(APPLE_PIE);
+        Item editedPie = new ItemBuilder(APPLE_PIE).withTags(VALID_TAG_POPULAR)
+                .build();
+        assertTrue(uniqueItemList.contains(editedPie));
+    }
+
+    @Test
+    public void add_nullItem_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueItemList.add(null));
+    }
+
+    @Test
+    public void add_duplicateItem_throwsDuplicateItemException() {
+        uniqueItemList.add(APPLE_PIE);
+        assertThrows(DuplicateItemException.class, () -> uniqueItemList.add(APPLE_PIE));
+    }
+
+    @Test
+    public void setItem_nullTargetItem_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueItemList.setItem(null, APPLE_PIE));
+    }
+
+    @Test
+    public void setItem_nullEditedItem_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueItemList.setItem(APPLE_PIE, null));
+    }
+
+    @Test
+    public void setItem_targetItemNotInList_throwsItemNotFoundException() {
+        assertThrows(ItemNotFoundException.class, () -> uniqueItemList.setItem(APPLE_PIE, APPLE_PIE));
+    }
+
+    @Test
+    public void setItem_editedItemIsSameItem_success() {
+        uniqueItemList.add(APPLE_PIE);
+        uniqueItemList.setItem(APPLE_PIE, APPLE_PIE);
+        UniqueItemList expectedUniqueItemList = new UniqueItemList();
+        expectedUniqueItemList.add(APPLE_PIE);
+        assertEquals(expectedUniqueItemList, uniqueItemList);
+    }
+
+    @Test
+    public void setItem_editedItemHasSameIdentity_success() {
+        uniqueItemList.add(APPLE_PIE);
+        Item editedPie = new ItemBuilder(APPLE_PIE).withTags(VALID_TAG_POPULAR).build();
+        uniqueItemList.setItem(APPLE_PIE, editedPie);
+        UniqueItemList expectedUniqueItemList = new UniqueItemList();
+        expectedUniqueItemList.add(editedPie);
+        assertEquals(expectedUniqueItemList, uniqueItemList);
+    }
+
+    @Test
+    public void setItem_editedItemHasDifferentIdentity_success() {
+        uniqueItemList.add(APPLE_PIE);
+        uniqueItemList.setItem(APPLE_PIE, BANANA_MUFFIN);
+        UniqueItemList expectedUniqueItemList = new UniqueItemList();
+        expectedUniqueItemList.add(BANANA_MUFFIN);
+        assertEquals(expectedUniqueItemList, uniqueItemList);
+    }
+
+    @Test
+    public void setItem_editedItemHasNonUniqueIdentity_throwsDuplicateItemException() {
+        uniqueItemList.add(APPLE_PIE);
+        uniqueItemList.add(BANANA_MUFFIN);
+        assertThrows(DuplicateItemException.class, () -> uniqueItemList.setItem(APPLE_PIE, BANANA_MUFFIN));
+    }
+
+    @Test
+    public void remove_nullItem_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueItemList.remove(null));
+    }
+
+    @Test
+    public void remove_itemDoesNotExist_throwsItemNotFoundException() {
+        assertThrows(ItemNotFoundException.class, () -> uniqueItemList.remove(APPLE_PIE));
+    }
+
+    @Test
+    public void remove_existingItem_removesItem() {
+        uniqueItemList.add(APPLE_PIE);
+        uniqueItemList.remove(APPLE_PIE);
+        UniqueItemList expectedUniqueItemList = new UniqueItemList();
+        assertEquals(expectedUniqueItemList, uniqueItemList);
+    }
+
+    @Test
+    public void setItems_nullUniqueItemList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueItemList.setItems((UniqueItemList) null));
+    }
+
+    @Test
+    public void setItems_uniqueItemList_replacesOwnListWithProvidedUniqueItemList() {
+        uniqueItemList.add(APPLE_PIE);
+        UniqueItemList expectedUniqueItemList = new UniqueItemList();
+        uniqueItemList.add(BANANA_MUFFIN);
+        this.uniqueItemList.setItems(expectedUniqueItemList);
+        assertEquals(expectedUniqueItemList, this.uniqueItemList);
+    }
+
+    @Test
+    public void setItems_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueItemList.setItems((List<Item>) null));
+    }
+
+    @Test
+    public void setItems_list_replacesOwnListWithProvidedList() {
+        uniqueItemList.add(APPLE_PIE);
+        List<Item> itemList = Collections.singletonList(BANANA_MUFFIN);
+        uniqueItemList.setItems(itemList);
+        UniqueItemList expectedUniqueItemList = new UniqueItemList();
+        expectedUniqueItemList.add(BANANA_MUFFIN);
+        assertEquals(expectedUniqueItemList, uniqueItemList);
+    }
+
+    @Test
+    public void setItems_listWithDuplicateItems_throwsDuplicateItemException() {
+        List<Item> listWithDuplicateItems = Arrays.asList(APPLE_PIE, APPLE_PIE);
+        assertThrows(DuplicateItemException.class, () -> uniqueItemList.setItems(listWithDuplicateItems));
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, ()
+            -> uniqueItemList.asUnmodifiableObservableList().remove(0));
+    }
+}

--- a/src/test/java/seedu/address/newmodel/tag/TagTest.java
+++ b/src/test/java/seedu/address/newmodel/tag/TagTest.java
@@ -1,0 +1,26 @@
+package seedu.address.newmodel.tag;
+
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class TagTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Tag(null));
+    }
+
+    @Test
+    public void constructor_invalidTagName_throwsIllegalArgumentException() {
+        String invalidTagName = "";
+        assertThrows(IllegalArgumentException.class, () -> new Tag(invalidTagName));
+    }
+
+    @Test
+    public void isValidTagName() {
+        // null tag name
+        assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/InventoryBuilder.java
+++ b/src/test/java/seedu/address/testutil/InventoryBuilder.java
@@ -1,0 +1,34 @@
+package seedu.address.testutil;
+
+import seedu.address.newmodel.item.Item;
+import seedu.address.newmodel.Inventory;
+
+/**
+ * A utility class to help with building Inventory objects.
+ * Example usage: <br>
+ *     {@code AddressBook ab = new AddressBookBuilder().withPerson("John", "Doe").build();}
+ */
+public class InventoryBuilder {
+
+    private Inventory inventory;
+
+    public InventoryBuilder() {
+        inventory = new Inventory();
+    }
+
+    public InventoryBuilder(Inventory inventory) {
+        this.inventory = inventory;
+    }
+
+    /**
+     * Adds a new {@code Item} to the {@code Inventory} that we are building.
+     */
+    public InventoryBuilder withItem(Item item) {
+        inventory.addItem(item);
+        return this;
+    }
+
+    public Inventory build() {
+        return inventory;
+    }
+}

--- a/src/test/java/seedu/address/testutil/InventoryBuilder.java
+++ b/src/test/java/seedu/address/testutil/InventoryBuilder.java
@@ -1,7 +1,7 @@
 package seedu.address.testutil;
 
-import seedu.address.newmodel.item.Item;
 import seedu.address.newmodel.Inventory;
+import seedu.address.newmodel.item.Item;
 
 /**
  * A utility class to help with building Inventory objects.

--- a/src/test/java/seedu/address/testutil/ItemBuilder.java
+++ b/src/test/java/seedu/address/testutil/ItemBuilder.java
@@ -3,10 +3,10 @@ package seedu.address.testutil;
 import java.util.HashSet;
 import java.util.Set;
 
-import seedu.address.model.tag.Tag;
-import seedu.address.newmodel.item.Name;
 import seedu.address.newmodel.item.Item;
-import seedu.address.model.util.SampleDataUtil;
+import seedu.address.newmodel.item.Name;
+import seedu.address.newmodel.tag.Tag;
+import seedu.address.newmodel.util.SampleDataUtil;
 
 /**
  * A utility class to help with building Person objects.

--- a/src/test/java/seedu/address/testutil/ItemBuilder.java
+++ b/src/test/java/seedu/address/testutil/ItemBuilder.java
@@ -1,0 +1,69 @@
+package seedu.address.testutil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import seedu.address.model.tag.Tag;
+import seedu.address.newmodel.item.Name;
+import seedu.address.newmodel.item.Item;
+import seedu.address.model.util.SampleDataUtil;
+
+/**
+ * A utility class to help with building Person objects.
+ */
+public class ItemBuilder {
+
+    public static final String DEFAULT_NAME = "Banana Muffin";
+    public static final String DEFAULT_ID = "#111111";
+
+    private Name name;
+    private String id;
+    private Set<Tag> tags;
+
+    /**
+     * Creates a {@code ItemBuilder} with the default details.
+     */
+    public ItemBuilder() {
+        name = new Name(DEFAULT_NAME);
+        id = DEFAULT_ID;
+        tags = new HashSet<>();
+    }
+
+    /**
+     * Initializes the ItemBuilder with the data of {@code itemToCopy}.
+     */
+    public ItemBuilder(Item itemToCopy) {
+        name = itemToCopy.getName();
+        id = itemToCopy.getId();
+        tags = new HashSet<>(itemToCopy.getTags());
+    }
+
+    /**
+     * Sets the {@code Name} of the {@code Item} that we are building.
+     */
+    public ItemBuilder withName(String name) {
+        this.name = new Name(name);
+        return this;
+    }
+
+    /**
+     * Sets the {@code id} of the {@code Item} that we are building.
+     */
+    public ItemBuilder withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Item} that we are building.
+     */
+    public ItemBuilder withTags(String ... tags) {
+        this.tags = SampleDataUtil.getTagSet(tags);
+        return this;
+    }
+
+    public Item build() {
+        return new Item(name, id, tags);
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/TypicalItems.java
+++ b/src/test/java/seedu/address/testutil/TypicalItems.java
@@ -1,0 +1,68 @@
+package seedu.address.testutil;
+
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BAKED;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_POPULAR;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.newmodel.Inventory;
+import seedu.address.newmodel.item.Item;
+
+/**
+ * A utility class containing a list of {@code Person} objects to be used in tests.
+ */
+public class TypicalItems {
+
+    public static final Item APPLE_PIE = new ItemBuilder().withName("Apple Pie")
+            .withId("#222222")
+            .withTags("baked").build();
+    public static final Item BANANA_MUFFIN = new ItemBuilder().withName("Banana Muffin")
+            .withId("#333333")
+            .withTags("baked", "bestseller").build();
+    public static final Item CHOCOCHIP = new ItemBuilder().withName("Chocholate Chip Cookie")
+            .withId("#444444")
+            .withTags("baked").build();
+    public static final Item DALGONA_COFFEE  = new ItemBuilder().withName("Dalgona Coffee")
+            .withId("#555555").build();
+    public static final Item EGGNOG = new ItemBuilder().withName("Egg Nog")
+            .withId("#666666").build();
+    public static final Item FOREST_CAKE = new ItemBuilder().withName("Forest Cake")
+            .withId("#777777").build();
+    public static final Item GRANOLA_BAR = new ItemBuilder().withName("Granola Bar")
+            .withId("#888888").build();
+
+    // Manually added
+    public static final Item HONEY_CAKE = new ItemBuilder().withName("Honey Cake").withId("#999999").build();
+    public static final Item ICE_CREAM = new ItemBuilder().withName("Ice Cream").withId("#000000").build();
+
+    // Manually added - Item's details found in {@code CommandTestUtil}
+    public static final Item BAGEL = new ItemBuilder()
+            .withName(VALID_NAME_BAGEL).withId("#123456").withTags(VALID_TAG_BAKED).build();
+    public static final Item DONUT = new ItemBuilder()
+            .withName(VALID_NAME_DONUT).withId("#789012").withTags(VALID_TAG_BAKED, VALID_TAG_POPULAR)
+            .build();
+
+    public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
+
+    private TypicalItems() {} // prevents instantiation
+
+    /**
+     * Returns an {@code Inventory} with all the typical items.
+     */
+    public static Inventory getTypicalInventory() {
+        Inventory typicalInventory = new Inventory();
+        for (Item item : getTypicalItems()) {
+            typicalInventory.addItem(item);
+        }
+        return typicalInventory;
+    }
+
+    public static List<Item> getTypicalItems() {
+        return new ArrayList<>(Arrays.asList(APPLE_PIE, BANANA_MUFFIN, CHOCOCHIP,
+                DALGONA_COFFEE, EGGNOG, FOREST_CAKE, GRANOLA_BAR));
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalItems.java
+++ b/src/test/java/seedu/address/testutil/TypicalItems.java
@@ -26,7 +26,7 @@ public class TypicalItems {
     public static final Item CHOCOCHIP = new ItemBuilder().withName("Chocholate Chip Cookie")
             .withId("#444444")
             .withTags("baked").build();
-    public static final Item DALGONA_COFFEE  = new ItemBuilder().withName("Dalgona Coffee")
+    public static final Item DALGONA_COFFEE = new ItemBuilder().withName("Dalgona Coffee")
             .withId("#555555").build();
     public static final Item EGGNOG = new ItemBuilder().withName("Egg Nog")
             .withId("#666666").build();


### PR DESCRIPTION
Fixes #12.

AB3 manages contacts and persons.

To contextualise the code for BogoBogo's use, we have to create an `Item` model. Let's create an `Item` class to eventually replace `Person`, and an `Inventory` class to replace `AddressBook`.

This pull request contains an added `Item` model that uses the current `Person` model as a skeletal structure. Logic of the new model package is largely preserved. The only significant difference between `Person` and `Item` is their data fields. 

Doing so, we can minimise the changes needed when we begin to integrate `Item` into the application.

Things that this Pull Request has **not** addressed:
* `Item` needs to be converted into JSON for data persistence
* `Item` needs to be integrated into the rest of the application
* `Item` needs to store information such as price, count, and cost