### PR TITLE
Modify delete command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -4,12 +4,12 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 
+import java.util.Optional;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.Name;
-
-import java.util.Optional;
 
 /**
  * Deletes an item identified using it's displayed index from the inventory.
@@ -87,7 +87,7 @@ public class DeleteCommand extends Command {
         DeleteCommand otherCommand = (DeleteCommand) other;
 
         return name.equals(otherCommand.name)
-           && id.equals(otherCommand.id)
-           && count == otherCommand.count;
+                && id.equals(otherCommand.id)
+                && count == otherCommand.count;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,10 +1,15 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.item.Item;
+import seedu.address.model.item.Name;
+
+import java.util.HashSet;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -17,12 +22,28 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
-        try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_COUNT);
+
+        // Check that either name (preamble) or id is specified, not both
+        if (!(argMultimap.getPreamble().isEmpty() ^ argMultimap.getValue(PREFIX_ID).isEmpty())) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        }
+
+        int count = -1;
+        if (argMultimap.getValue(PREFIX_COUNT).isPresent()) {
+            count = ParserUtil.parseCount(argMultimap.getValue(PREFIX_COUNT).get());
+        }
+
+        if (!argMultimap.getPreamble().isEmpty()) {
+            // name specified
+            Name name = new Name(argMultimap.getPreamble());
+            return new DeleteCommand(name, count);
+        } else {
+            // id specified
+            String id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
+            return new DeleteCommand(id, count);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -6,10 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.item.Item;
 import seedu.address.model.item.Name;
-
-import java.util.HashSet;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object

--- a/src/main/java/seedu/address/model/Inventory.java
+++ b/src/main/java/seedu/address/model/Inventory.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.item.Item;

--- a/src/main/java/seedu/address/model/Inventory.java
+++ b/src/main/java/seedu/address/model/Inventory.java
@@ -4,9 +4,11 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.Name;
 import seedu.address.model.item.UniqueItemList;
 
 /**
@@ -61,11 +63,28 @@ public class Inventory implements ReadOnlyInventory {
     //// item-level operations
 
     /**
-     * Returns true if an item with the same id as {@code item} that exists in the inventory.
+     * Returns true if an item with the same identity fields as {@code item} that exists in the inventory.
+     * @see Item#isSameItem(Item)
      */
     public boolean hasItem(Item item) {
         requireNonNull(item);
         return items.contains(item);
+    }
+
+    /**
+     * Returns true if an item with the given {@code name} exists in the inventory.
+     */
+    public boolean hasItem(Name name) {
+        requireNonNull(name);
+        return items.contains(name);
+    }
+
+    /**
+     * Returns true if an item with the given {@code id} exists in the inventory.
+     */
+    public boolean hasItem(String id) {
+        requireNonNull(id);
+        return items.contains(id);
     }
 
     /**
@@ -177,11 +196,53 @@ public class Inventory implements ReadOnlyInventory {
     }
 
     /**
-     * Removes {@code key} from this {@code Inventory}.
-     * {@code key} must exist in the inventory.
+     * Removes the specified amount of item with the given {@code name} from this {@code Inventory}.
+     * If amount of item drops to 0 or less, remove the entire item from inventory
+     * The specified item must exist in the inventory.
+     * @param name name of item to remove
+     * @param amount number of the item to remove, set to -1 to remove all.
+     * @returns the deleted item
      */
-    public void removeItem(Item key) {
-        items.remove(key);
+    public Item removeItem(Name name, Integer amount) {
+        requireNonNull(name);
+
+        Item existingItem = items.getItem(name).get();
+        items.remove(existingItem);
+
+        int amountDeleted = (amount == -1)
+                ? existingItem.getCount() : Math.min(amount, existingItem.getCount());
+
+        int newCount = existingItem.getCount() - amountDeleted;
+        if (newCount > 0) {
+            items.add(existingItem.updateCount(newCount));
+        }
+
+        return existingItem.updateCount(amountDeleted);
+    }
+
+    /**
+     * Removes the specified amount of item with the given {@code id} from this {@code Inventory}.
+     * If amount of item drops to 0 or less, remove the entire item from inventory
+     * The specified item must exist in the inventory.
+     * @param id id of item to remove
+     * @param amount amount of the item to remove, set to -1 to remove all.
+     * @returns the deleted item
+     */
+    public Item removeItem(String id, Integer amount) {
+        requireNonNull(id);
+
+        Item existingItem = items.getItem(id).get();
+        items.remove(existingItem);
+
+        int amountDeleted = (amount == -1)
+                ? existingItem.getCount() : Math.min(amount, existingItem.getCount());
+
+        int newCount = existingItem.getCount() - amountDeleted;
+        if (newCount > 0) {
+            items.add(existingItem.updateCount(newCount));
+        }
+
+        return existingItem.updateCount(amountDeleted);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -7,6 +7,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.Name;
 
 /**
  * The API of the Model component.
@@ -41,9 +42,9 @@ public interface Model {
     Path getInventoryFilePath();
 
     /**
-     * Sets the user prefs' address book file path.
+     * Sets the user prefs' inventory file path.
      */
-    void setInventoryFilePath(Path addressBookFilePath);
+    void setInventoryFilePath(Path inventoryFilePath);
 
     /**
      * Replaces inventory data with the data in {@code inventory}.
@@ -54,15 +55,38 @@ public interface Model {
     ReadOnlyInventory getInventory();
 
     /**
-     * Returns true if a item with the same identity as {@code item} exists in the inventory.
+     * Returns true if an item with the given {@code id} exists in the inventory.
+     * @see Item#isSameItem
      */
     boolean hasItem(Item item);
 
     /**
-     * Deletes the given item.
-     * The item must exist in the inventory.
+     * Returns true if an item with the given {@code name} exists in the inventory.
      */
-    void deleteItem(Item target);
+    boolean hasItem(Name name);
+
+    /**
+     * Returns true if an item with the given {@code id} exists in the inventory.
+     */
+    boolean hasItem(String id);
+
+    /**
+     * Deletes item in the inventory with the given name.
+     * The item must exist in the inventory.
+     * @param name name of the item to remove
+     * @param count count of the item to remove, set to -1 to remove all
+     * @returns the deleted item
+     */
+    Item deleteItem(Name name, int count);
+
+    /**
+     * Deletes item in the inventory with the given id.
+     * The item must exist in the inventory.
+     * @param id id of the item to remove
+     * @param count count of the item to remove, set to -1 to remove all
+     * @returns the deleted item
+     */
+    Item deleteItem(String id, int count);
 
     /**
      * Adds the given item.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -14,9 +14,10 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.Name;
 
 /**
- * Represents the in-memory model of the address book data.
+ * Represents the in-memory model of BogoBogo data.
  */
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
@@ -27,13 +28,13 @@ public class ModelManager implements Model {
     private Optional<Order> optionalOrder;
 
     /**
-     * Initializes a ModelManager with the given addressBook and userPrefs.
+     * Initializes a ModelManager with the given inventory and userPrefs.
      */
     public ModelManager(ReadOnlyInventory inventory, ReadOnlyUserPrefs userPrefs) {
         super();
         requireAllNonNull(inventory, userPrefs);
 
-        logger.fine("Initializing with address book: " + inventory + " and user prefs " + userPrefs);
+        logger.fine("Initializing with inventory: " + inventory + " and user prefs " + userPrefs);
 
         this.inventory = new Inventory(inventory);
         this.userPrefs = new UserPrefs(userPrefs);
@@ -99,8 +100,25 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void deleteItem(Item target) {
-        inventory.removeItem(target);
+    public boolean hasItem(Name name) {
+        requireNonNull(name);
+        return inventory.hasItem(name);
+    }
+
+    @Override
+    public boolean hasItem(String id) {
+        requireNonNull(id);
+        return inventory.hasItem(id);
+    }
+
+    @Override
+    public Item deleteItem(Name name, int count) {
+        return inventory.removeItem(name, count);
+    }
+
+    @Override
+    public Item deleteItem(String id, int count) {
+        return inventory.removeItem(id, count);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -122,6 +122,7 @@ public class Item {
         Item otherItem = (Item) other;
         return otherItem.getName().equals(getName())
                 && otherItem.getId().equals(getId())
+                && otherItem.getCount().equals(getCount())
                 && otherItem.getTags().equals(getTags());
     }
 

--- a/src/main/java/seedu/address/model/item/UniqueItemList.java
+++ b/src/main/java/seedu/address/model/item/UniqueItemList.java
@@ -58,13 +58,13 @@ public class UniqueItemList implements Iterable<Item> {
     /**
      * Returns an optional of the item in the list with the same identity fields.
      * If item does not exist, return an empty optional.
-     * @see Item#isSameItem(Item) 
+     * @see Item#isSameItem(Item)
      */
     public Optional<Item> getItem(Item item) {
         requireNonNull(item);
         return internalList.stream().filter(item::equals).findFirst();
     }
-    
+
     /**
      * Returns an optional of the item in the list with the given {@code name}.
      * If item does not exist, return an empty optional.

--- a/src/main/java/seedu/address/model/item/UniqueItemList.java
+++ b/src/main/java/seedu/address/model/item/UniqueItemList.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -31,10 +32,57 @@ public class UniqueItemList implements Iterable<Item> {
 
     /**
      * Returns true if the list contains an equivalent item as the given argument.
+     * @see Item#isSameItem(Item)
      */
     public boolean contains(Item toCheck) {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(toCheck::isSameItem);
+    }
+
+    /**
+     * Returns true if the list contains an item with the given name
+     */
+    public boolean contains(Name name) {
+        requireNonNull(name);
+        return internalList.stream().anyMatch(item -> name.equals(item.getName()));
+    }
+
+    /**
+     * Returns true if the list contains an item with the given id
+     */
+    public boolean contains(String id) {
+        requireNonNull(id);
+        return internalList.stream().anyMatch(item -> id.equals(item.getId()));
+    }
+
+    /**
+     * Returns an optional of the item in the list with the same identity fields.
+     * If item does not exist, return an empty optional.
+     * @see Item#isSameItem(Item) 
+     */
+    public Optional<Item> getItem(Item item) {
+        requireNonNull(item);
+        return internalList.stream().filter(item::equals).findFirst();
+    }
+    
+    /**
+     * Returns an optional of the item in the list with the given {@code name}.
+     * If item does not exist, return an empty optional.
+     */
+    public Optional<Item> getItem(Name name) {
+        requireNonNull(name);
+        return internalList.stream()
+                .filter(item -> item.getName().equals(name)).findFirst();
+    }
+
+    /**
+     * Returns an optional of the item in the list with the given {@code id}.
+     * If item does not exist, return an empty optional.
+     */
+    public Optional<Item> getItem(String id) {
+        requireNonNull(id);
+        return internalList.stream()
+                .filter(item -> item.getId().equals(id)).findFirst();
     }
 
     /**
@@ -47,6 +95,8 @@ public class UniqueItemList implements Iterable<Item> {
             throw new DuplicateItemException();
         }
         internalList.add(toAdd);
+
+        getItem(toAdd);
     }
 
     /**
@@ -70,11 +120,13 @@ public class UniqueItemList implements Iterable<Item> {
     }
 
     /**
-     * Removes the equivalent item from the list.
+     * Removes the specified count of the equivalent item from the list.
+     * If item is
      * The item must exist in the list.
      */
     public void remove(Item toRemove) {
         requireNonNull(toRemove);
+
         if (!internalList.remove(toRemove)) {
             throw new ItemNotFoundException();
         }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -57,8 +58,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);
+        String deleteCommand = "delete apple pie";
+        assertCommandException(deleteCommand, String.format(DeleteCommand.MESSAGE_ITEM_NAME_NOT_FOUND, "apple pie"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BAGEL;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -18,6 +18,7 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.Inventory;
 import seedu.address.model.Model;
+import seedu.address.model.ModelStub;
 import seedu.address.model.Order;
 import seedu.address.model.ReadOnlyInventory;
 import seedu.address.model.ReadOnlyUserPrefs;
@@ -78,122 +79,7 @@ public class AddCommandTest {
         // different item -> returns false
         assertFalse(addBagelCommand.equals(addDonutCommand));
     }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getInventoryFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setInventoryFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addItem(Item item) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setInventory(ReadOnlyInventory newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyInventory getInventory() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasItem(Item item) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteItem(Item target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setItem(Item target, Item editedItem) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void sortItems(Comparator<Item> comparator) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Item> getFilteredItemList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredItemList(Predicate<Item> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Item getItemWithName(String name) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Item getItemWithId(String id) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setOrder(Order order) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasUnclosedOrder() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addToOrder(Item item) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void removeFromOrder(Item item) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void transactAndClearOrder() {
-            throw new AssertionError("This method should not be called.");
-        }
-    }
-
+    
     /**
      * A Model stub that contains a single item.
      */

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -6,22 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.Inventory;
-import seedu.address.model.Model;
 import seedu.address.model.ModelStub;
-import seedu.address.model.Order;
 import seedu.address.model.ReadOnlyInventory;
-import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.item.Item;
 import seedu.address.testutil.ItemBuilder;
 
@@ -79,7 +71,7 @@ public class AddCommandTest {
         // different item -> returns false
         assertFalse(addBagelCommand.equals(addDonutCommand));
     }
-    
+
     /**
      * A Model stub that contains a single item.
      */

--- a/src/test/java/seedu/address/logic/commands/AddToOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddToOrderCommandTest.java
@@ -3,21 +3,14 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Optional;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.Model;
+import seedu.address.model.ModelStub;
 import seedu.address.model.Order;
-import seedu.address.model.ReadOnlyInventory;
-import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.Name;
 
@@ -57,7 +50,7 @@ public class AddToOrderCommandTest {
     /**
      * A model stub that has only order related functionality.
      */
-    private class ModelStubWithOrder implements Model {
+    private class ModelStubWithOrder extends ModelStub {
         private Optional<Order> optionalOrder;
 
         ModelStubWithOrder() {
@@ -65,96 +58,8 @@ public class AddToOrderCommandTest {
         }
 
         @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getInventoryFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setInventoryFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addItem(Item item) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setInventory(ReadOnlyInventory newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyInventory getInventory() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasItem(Item item) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteItem(Item target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setItem(Item target, Item editedItem) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        /**
-         * Sorts the item list using the given {@code comparator}.
-         */
-        @Override
-        public void sortItems(Comparator<Item> comparator) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Item> getFilteredItemList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredItemList(Predicate<Item> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Item getItemWithName(String name) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Item getItemWithId(String id) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public void setOrder(Order order) {
-            ModelStubWithOrder.this.optionalOrder = Optional.of(order);
+            this.optionalOrder = Optional.of(order);
         }
 
         @Override
@@ -165,17 +70,7 @@ public class AddToOrderCommandTest {
         @Override
         public void addToOrder(Item item) {
             assert hasUnclosedOrder();
-            optionalOrder.get().addItem(item);
-        }
-
-        @Override
-        public void removeFromOrder(Item item) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void transactAndClearOrder() {
-            throw new AssertionError("This method should not be called.");
+            optionalOrder.get().addItem(item);;
         }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -2,21 +2,20 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_DONUT;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showItemAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
+import static seedu.address.testutil.TypicalItems.APPLE_PIE;
+import static seedu.address.testutil.TypicalItems.BAGEL;
 import static seedu.address.testutil.TypicalItems.getTypicalInventory;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.core.Messages;
-import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.item.Item;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -27,65 +26,57 @@ public class DeleteCommandTest {
     private Model model = new ModelManager(getTypicalInventory(), new UserPrefs());
 
     @Test
-    public void execute_validIndexUnfilteredList_success() {
-        Item itemToDelete = model.getFilteredItemList().get(INDEX_FIRST_ITEM.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_ITEM);
-
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_ITEM_SUCCESS, itemToDelete);
-
-        ModelManager expectedModel = new ModelManager(model.getInventory(), new UserPrefs());
-        expectedModel.deleteItem(itemToDelete);
-
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredItemList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
-
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);
-    }
-
-    @Test
-    public void execute_validIndexFilteredList_success() {
-        showItemAtIndex(model, INDEX_FIRST_ITEM);
-
-        Item itemToDelete = model.getFilteredItemList().get(INDEX_FIRST_ITEM.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_ITEM);
-
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_ITEM_SUCCESS, itemToDelete);
+    public void execute_deleteExistingItemByName_success() {
+        DeleteCommand deleteCommand = new DeleteCommand(APPLE_PIE.getName(), 1);
 
         Model expectedModel = new ModelManager(model.getInventory(), new UserPrefs());
-        expectedModel.deleteItem(itemToDelete);
-        showNoItem(expectedModel);
+        expectedModel.deleteItem(APPLE_PIE.getName(), 1);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_ITEM_SUCCESS, APPLE_PIE.updateCount(1));
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
-    public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showItemAtIndex(model, INDEX_FIRST_ITEM);
+    public void execute_deleteExistingItemById_success() {
+        DeleteCommand deleteCommand = new DeleteCommand(APPLE_PIE.getId(), 1);
 
-        Index outOfBoundIndex = INDEX_SECOND_ITEM;
-        // ensures that outOfBoundIndex is still in bounds of inventory list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getInventory().getItemList().size());
+        Model expectedModel = new ModelManager(model.getInventory(), new UserPrefs());
+        expectedModel.deleteItem(APPLE_PIE.getId(), 1);
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_ITEM_SUCCESS, APPLE_PIE.updateCount(1));
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_nonexistentName_throwsCommandException() {
+        DeleteCommand deleteCommand = new DeleteCommand(BAGEL.getName(), -1);
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_ITEM_NAME_NOT_FOUND, BAGEL.getName());
+
+        assertCommandFailure(deleteCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_nonexistentId_throwsCommandException() {
+        DeleteCommand deleteCommand = new DeleteCommand(BAGEL.getId(), -1);
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_ITEM_ID_NOT_FOUND, BAGEL.getId());
+
+        assertCommandFailure(deleteCommand, model, expectedMessage);
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_ITEM);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_ITEM);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(VALID_NAME_BAGEL, -1);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(VALID_NAME_DONUT, -1);
+        DeleteCommand deleteThirdCommand = new DeleteCommand(VALID_ID_BAGEL, -1);
+        DeleteCommand deleteFourthCommand = new DeleteCommand(VALID_NAME_DONUT, 2);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_ITEM);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(VALID_NAME_BAGEL, -1);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -94,16 +85,11 @@ public class DeleteCommandTest {
         // null -> returns false
         assertFalse(deleteFirstCommand.equals(null));
 
-        // different item -> returns false
+        // different values -> returns false
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
-    }
-
-    /**
-     * Updates {@code model}'s filtered list to show no one.
-     */
-    private void showNoItem(Model model) {
-        model.updateFilteredItemList(p -> false);
-
-        assertTrue(model.getFilteredItemList().isEmpty());
+        // different id -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteThirdCommand));
+        // different count -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteFourthCommand));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EndAndTransactOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EndAndTransactOrderCommandTest.java
@@ -3,22 +3,16 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Optional;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Inventory;
-import seedu.address.model.Model;
+import seedu.address.model.ModelStub;
 import seedu.address.model.Order;
 import seedu.address.model.ReadOnlyInventory;
-import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.TransactionRecord;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.Name;
@@ -102,7 +96,7 @@ public class EndAndTransactOrderCommandTest {
     /**
      * A model stub that has only order related functionality.
      */
-    private class ModelStubWithOrderAndInventory implements Model {
+    private class ModelStubWithOrderAndInventory extends ModelStub {
         private Optional<Order> optionalOrder;
         private Inventory inventory;
 
@@ -112,91 +106,8 @@ public class EndAndTransactOrderCommandTest {
         }
 
         @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getInventoryFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setInventoryFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addItem(Item item) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public void setInventory(ReadOnlyInventory newData) {
             inventory.resetData(newData);
-        }
-
-        @Override
-        public ReadOnlyInventory getInventory() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasItem(Item item) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteItem(Item target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setItem(Item target, Item editedItem) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        /**
-         * Sorts the item list using the given {@code comparator}.
-         */
-        @Override
-        public void sortItems(Comparator<Item> comparator) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Item> getFilteredItemList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredItemList(Predicate<Item> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Item getItemWithName(String name) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Item getItemWithId(String id) {
-            throw new AssertionError("This method should not be called.");
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/RemoveFromOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemoveFromOrderCommandTest.java
@@ -3,23 +3,16 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.Model;
+import seedu.address.model.ModelStub;
 import seedu.address.model.Order;
-import seedu.address.model.ReadOnlyInventory;
-import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.Name;
 
@@ -94,99 +87,11 @@ public class RemoveFromOrderCommandTest {
     /**
      * A model stub that has only order related functionality.
      */
-    private class ModelStubWithOrder implements Model {
+    private class ModelStubWithOrder extends ModelStub {
         private Optional<Order> optionalOrder;
 
         ModelStubWithOrder() {
             optionalOrder = Optional.empty();
-        }
-
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getInventoryFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setInventoryFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addItem(Item item) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setInventory(ReadOnlyInventory newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyInventory getInventory() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasItem(Item item) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteItem(Item target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setItem(Item target, Item editedItem) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        /**
-         * Sorts the item list using the given {@code comparator}.
-         */
-        @Override
-        public void sortItems(Comparator<Item> comparator) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Item> getFilteredItemList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredItemList(Predicate<Item> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Item getItemWithName(String name) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Item getItemWithId(String id) {
-            throw new AssertionError("This method should not be called.");
         }
 
         @Override
@@ -211,9 +116,5 @@ public class RemoveFromOrderCommandTest {
             optionalOrder.get().removeItem(item);
         }
 
-        @Override
-        public void transactAndClearOrder() {
-            throw new AssertionError("This method should not be called.");
-        }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/StartOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/StartOrderCommandTest.java
@@ -3,20 +3,13 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.Optional;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.Model;
+import seedu.address.model.ModelStub;
 import seedu.address.model.Order;
-import seedu.address.model.ReadOnlyInventory;
-import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.item.Item;
 
 public class StartOrderCommandTest {
@@ -39,99 +32,11 @@ public class StartOrderCommandTest {
     /**
      * A model stub that has only order related functionality.
      */
-    private class ModelStubWithOrder implements Model {
+    private class ModelStubWithOrder extends ModelStub {
         private Optional<Order> optionalOrder;
 
         ModelStubWithOrder() {
             optionalOrder = Optional.empty();
-        }
-
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getInventoryFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setInventoryFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addItem(Item item) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setInventory(ReadOnlyInventory newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyInventory getInventory() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasItem(Item item) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteItem(Item target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setItem(Item target, Item editedItem) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        /**
-         * Sorts the item list using the given {@code comparator}.
-         */
-        @Override
-        public void sortItems(Comparator<Item> comparator) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Item> getFilteredItemList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredItemList(Predicate<Item> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Item getItemWithName(String name) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Item getItemWithId(String id) {
-            throw new AssertionError("This method should not be called.");
         }
 
         @Override
@@ -147,17 +52,7 @@ public class StartOrderCommandTest {
         @Override
         public void addToOrder(Item item) {
             assert hasUnclosedOrder();
-            optionalOrder.get().addItem(item);
-        }
-
-        @Override
-        public void removeFromOrder(Item item) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void transactAndClearOrder() {
-            throw new AssertionError("This method should not be called.");
+            optionalOrder.get().addItem(item);;
         }
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -51,9 +51,9 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_delete() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_ITEM.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_ITEM), command);
+        Item item = new ItemBuilder().build();
+        DeleteCommand command = (DeleteCommand) parser.parseCommand(ItemUtil.getDeleteCommand(item));
+        assertEquals(new DeleteCommand(item.getName(), item.getCount()), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,12 +1,10 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BAGEL;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BAGEL;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_BAKED;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalItems.BAGEL;

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,17 +1,24 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_BAKED;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+import static seedu.address.testutil.TypicalItems.BAGEL;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.model.item.Name;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
+ * outside of the DeleteCommand code. For example, inputs "apple" and "apple t/fruit" take the
  * same path through the DeleteCommand, and therefore we test only one of them.
  * The path variation for those two cases occur inside the ParserUtil, and
  * therefore should be covered by the ParserUtilTest.
@@ -21,12 +28,27 @@ public class DeleteCommandParserTest {
     private DeleteCommandParser parser = new DeleteCommandParser();
 
     @Test
-    public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_ITEM));
+    public void parse_nameNoId_returnsDeleteCommand() {
+        // name only
+        assertParseSuccess(parser, VALID_NAME_BAGEL, new DeleteCommand(new Name(VALID_NAME_BAGEL), -1));
+        // name and count
+        assertParseSuccess(parser, VALID_NAME_BAGEL + " " + COUNT_DESC_BAGEL,
+                new DeleteCommand(new Name(VALID_NAME_BAGEL), BAGEL.getCount()));
     }
 
     @Test
-    public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    public void parse_idNoName_returnsDeleteCommand() {
+        // id only
+        assertParseSuccess(parser, ID_DESC_BAGEL, new DeleteCommand(VALID_ID_BAGEL, -1));
+        // id and count
+        assertParseSuccess(parser, ID_DESC_BAGEL + " " + COUNT_DESC_BAGEL,
+                new DeleteCommand(VALID_ID_BAGEL, BAGEL.getCount()));
+    }
+
+
+    @Test
+    public void parse_bothNameOrId_throwsParseException() {
+        assertParseFailure(parser, VALID_NAME_BAGEL + " " + ID_DESC_BAGEL,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/model/InventoryTest.java
+++ b/src/test/java/seedu/address/model/InventoryTest.java
@@ -3,6 +3,8 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_POPULAR;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalItems.APPLE_PIE;
@@ -18,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.Name;
 import seedu.address.model.item.exceptions.DuplicateItemException;
 import seedu.address.testutil.ItemBuilder;
 
@@ -54,7 +57,9 @@ public class InventoryTest {
 
     @Test
     public void hasItem_nullItem_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> inventory.hasItem(null));
+        assertThrows(NullPointerException.class, () -> inventory.hasItem((Item) null));
+        assertThrows(NullPointerException.class, () -> inventory.hasItem((Name) null));
+        assertThrows(NullPointerException.class, () -> inventory.hasItem((String) null));
     }
 
     @Test
@@ -71,8 +76,77 @@ public class InventoryTest {
     @Test
     public void hasItem_itemWithSameIdentityFieldsInInventory_returnsTrue() {
         inventory.addItem(APPLE_PIE);
+
+        // Search by item
         Item editedPie = new ItemBuilder(APPLE_PIE).withTags(VALID_TAG_POPULAR).build();
         assertTrue(inventory.hasItem(editedPie));
+
+        // Search by name
+        assertTrue(inventory.hasItem(APPLE_PIE.getName()));
+
+        // Search by id
+        assertTrue(inventory.hasItem(APPLE_PIE.getId()));
+    }
+
+    @Test
+    public void removeItemByName_removeAll_success() {
+        inventory.addItem(APPLE_PIE);
+
+        assertEquals(APPLE_PIE, inventory.removeItem(APPLE_PIE.getName(), -1));
+        assertFalse(inventory.hasItem(APPLE_PIE));
+    }
+
+    @Test
+    public void removeItemById_removeAll_success() {
+        inventory.addItem(APPLE_PIE);
+
+        assertEquals(APPLE_PIE, inventory.removeItem(APPLE_PIE.getId(), -1));
+        assertFalse(inventory.hasItem(APPLE_PIE));
+    }
+
+    @Test
+    public void removeItemByName_someOfItem_success() {
+        inventory.addItem(APPLE_PIE);
+
+        int expectedCount = APPLE_PIE.getCount() - 1;
+        Inventory expectedInventory = new Inventory();
+        expectedInventory.addItem(APPLE_PIE.updateCount(expectedCount));
+
+        assertEquals(APPLE_PIE.updateCount(1), inventory.removeItem(APPLE_PIE.getName(), 1));
+        assertEquals(inventory, expectedInventory);
+    }
+
+
+    @Test
+    public void removeItemById_someOfItem_success() {
+        inventory.addItem(APPLE_PIE);
+
+        int expectedCount = APPLE_PIE.getCount() - 1;
+        Inventory expectedInventory = new Inventory();
+        expectedInventory.addItem(APPLE_PIE.updateCount(expectedCount));
+
+        assertEquals(APPLE_PIE.updateCount(1), inventory.removeItem(APPLE_PIE.getId(), 1));
+        assertEquals(inventory, expectedInventory);
+    }
+
+    @Test
+    public void removeItemByName_removeTooMuch_success() {
+        inventory.addItem(APPLE_PIE);
+
+        int amount = APPLE_PIE.getCount() + 1;
+
+        assertEquals(APPLE_PIE, inventory.removeItem(APPLE_PIE.getName(), amount));
+        assertFalse(inventory.hasItem(APPLE_PIE));
+    }
+
+    @Test
+    public void removeItemById_removeTooMuch_success() {
+        inventory.addItem(APPLE_PIE);
+
+        int amount = APPLE_PIE.getCount() + 1;
+
+        assertEquals(APPLE_PIE, inventory.removeItem(APPLE_PIE.getId(), amount));
+        assertFalse(inventory.hasItem(APPLE_PIE));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/InventoryTest.java
+++ b/src/test/java/seedu/address/model/InventoryTest.java
@@ -3,8 +3,6 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BAGEL;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_POPULAR;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalItems.APPLE_PIE;

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -77,18 +77,33 @@ public class ModelManagerTest {
 
     @Test
     public void hasItem_nullItem_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> modelManager.hasItem(null));
+        //Search by item
+        assertThrows(NullPointerException.class, () -> modelManager.hasItem((Item)null));
+        //Search by name
+        assertThrows(NullPointerException.class, () -> modelManager.hasItem((Name)null));
+        //Search by id
+        assertThrows(NullPointerException.class, () -> modelManager.hasItem((String)null));
     }
 
     @Test
     public void hasItem_itemNotInInventory_returnsFalse() {
+        // Search by item
         assertFalse(modelManager.hasItem(APPLE_PIE));
+        // Search by name
+        assertFalse(modelManager.hasItem(APPLE_PIE.getName()));
+        // Search by id
+        assertFalse(modelManager.hasItem(APPLE_PIE.getId()));
     }
 
     @Test
     public void hasItem_itemInInventory_returnsTrue() {
         modelManager.addItem(APPLE_PIE);
+        // Search by item
         assertTrue(modelManager.hasItem(APPLE_PIE));
+        // Search by name
+        assertTrue(modelManager.hasItem(APPLE_PIE.getName()));
+        // Search by id
+        assertTrue(modelManager.hasItem(APPLE_PIE.getId()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -78,11 +78,11 @@ public class ModelManagerTest {
     @Test
     public void hasItem_nullItem_throwsNullPointerException() {
         //Search by item
-        assertThrows(NullPointerException.class, () -> modelManager.hasItem((Item)null));
+        assertThrows(NullPointerException.class, () -> modelManager.hasItem((Item) null));
         //Search by name
-        assertThrows(NullPointerException.class, () -> modelManager.hasItem((Name)null));
+        assertThrows(NullPointerException.class, () -> modelManager.hasItem((Name) null));
         //Search by id
-        assertThrows(NullPointerException.class, () -> modelManager.hasItem((String)null));
+        assertThrows(NullPointerException.class, () -> modelManager.hasItem((String) null));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -1,0 +1,135 @@
+package seedu.address.model;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.item.Item;
+import seedu.address.model.item.Name;
+
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.function.Predicate;
+
+/**
+ * A default model stub that have all of its methods failing.
+ */
+public class ModelStub implements Model {
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Path getInventoryFilePath() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setInventoryFilePath(Path addressBookFilePath) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addItem(Item item) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setInventory(ReadOnlyInventory newData) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyInventory getInventory() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasItem(Item item) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasItem(Name name) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasItem(String id) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Item deleteItem(Name name, int count) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Item deleteItem(String id, int count) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setItem(Item target, Item editedItem) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void sortItems(Comparator<Item> comparator) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Item> getFilteredItemList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredItemList(Predicate<Item> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Item getItemWithName(String name) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setOrder(Order order) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasUnclosedOrder() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addToOrder(Item item) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void removeFromOrder(Item item) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void transactAndClearOrder() {
+        throw new AssertionError("This method should not be called.");
+    }
+}

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -1,18 +1,19 @@
 package seedu.address.model;
 
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.function.Predicate;
+
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.Name;
 
-import java.nio.file.Path;
-import java.util.Comparator;
-import java.util.function.Predicate;
-
 /**
  * A default model stub that have all of its methods failing.
  */
 public class ModelStub implements Model {
+
     @Override
     public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
         throw new AssertionError("This method should not be called.");
@@ -105,6 +106,11 @@ public class ModelStub implements Model {
 
     @Override
     public Item getItemWithName(String name) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Item getItemWithId(String id) {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/model/item/ItemTest.java
+++ b/src/test/java/seedu/address/model/item/ItemTest.java
@@ -76,6 +76,11 @@ public class ItemTest {
         editedPie = new ItemBuilder(APPLE_PIE).withId(VALID_ID_BAGEL).build();
         assertFalse(APPLE_PIE.equals(editedPie));
 
+        // different count -> returns false
+        String diffCount = String.valueOf(APPLE_PIE.getCount() + 1);
+        editedPie = new ItemBuilder(APPLE_PIE).withCount(diffCount).build();
+        assertFalse(APPLE_PIE.equals(editedPie));
+
         // different tags -> returns false
         editedPie = new ItemBuilder(APPLE_PIE).withTags(VALID_TAG_POPULAR).build();
         assertFalse(APPLE_PIE.equals(editedPie));

--- a/src/test/java/seedu/address/model/item/UniqueItemListTest.java
+++ b/src/test/java/seedu/address/model/item/UniqueItemListTest.java
@@ -25,9 +25,9 @@ public class UniqueItemListTest {
 
     @Test
     public void contains_nullItem_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniqueItemList.contains((Item)null));
-        assertThrows(NullPointerException.class, () -> uniqueItemList.contains((Name)null));
-        assertThrows(NullPointerException.class, () -> uniqueItemList.contains((String)null));
+        assertThrows(NullPointerException.class, () -> uniqueItemList.contains((Item) null));
+        assertThrows(NullPointerException.class, () -> uniqueItemList.contains((Name) null));
+        assertThrows(NullPointerException.class, () -> uniqueItemList.contains((String) null));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/item/UniqueItemListTest.java
+++ b/src/test/java/seedu/address/model/item/UniqueItemListTest.java
@@ -25,18 +25,31 @@ public class UniqueItemListTest {
 
     @Test
     public void contains_nullItem_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniqueItemList.contains(null));
+        assertThrows(NullPointerException.class, () -> uniqueItemList.contains((Item)null));
+        assertThrows(NullPointerException.class, () -> uniqueItemList.contains((Name)null));
+        assertThrows(NullPointerException.class, () -> uniqueItemList.contains((String)null));
     }
 
     @Test
     public void contains_itemNotInList_returnsFalse() {
+        // Search by item
         assertFalse(uniqueItemList.contains(APPLE_PIE));
+        // Search by name
+        assertFalse(uniqueItemList.contains(APPLE_PIE.getName()));
+        // Search by id
+        assertFalse(uniqueItemList.contains(APPLE_PIE.getId()));
     }
 
     @Test
     public void contains_itemInList_returnsTrue() {
         uniqueItemList.add(APPLE_PIE);
+
+        // Search by item
         assertTrue(uniqueItemList.contains(APPLE_PIE));
+        // Search by name
+        assertTrue(uniqueItemList.contains(APPLE_PIE.getName()));
+        // Search by id
+        assertTrue(uniqueItemList.contains(APPLE_PIE.getId()));
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonInventoryStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonInventoryStorageTest.java
@@ -73,7 +73,7 @@ public class JsonInventoryStorageTest {
 
         // Modify data, overwrite exiting file, and read back
         original.addItem(HONEY_CAKE);
-        original.removeItem(APPLE_PIE);
+        original.removeItem(APPLE_PIE.getName(), 1);
         jsonInventoryStorage.saveInventory(original, filePath);
         readBack = jsonInventoryStorage.readInventory(filePath).get();
         assertEquals(original, new Inventory(readBack));

--- a/src/test/java/seedu/address/testutil/ItemUtil.java
+++ b/src/test/java/seedu/address/testutil/ItemUtil.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import java.util.Set;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand.EditItemDescriptor;
 import seedu.address.model.item.Item;
 import seedu.address.model.tag.Tag;
@@ -22,6 +23,15 @@ public class ItemUtil {
      */
     public static String getAddCommand(Item item) {
         return AddCommand.COMMAND_WORD + " " + getItemDetails(item);
+    }
+
+    /**
+     * Returns a delete command string for adding the {@code item}.
+     */
+    public static String getDeleteCommand(Item item) {
+        return DeleteCommand.COMMAND_WORD
+                + " " + item.getName()
+                + " " + PREFIX_COUNT + item.getCount();
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/TypicalItems.java
+++ b/src/test/java/seedu/address/testutil/TypicalItems.java
@@ -81,7 +81,7 @@ public class TypicalItems {
     }
 
     public static List<Item> getTypicalItems() {
-        return new ArrayList<>(Arrays.asList(APPLE_PIE, BANANA_MUFFIN, CHOCOCHIP,
+        return new ArrayList<>(Arrays.asList(APPLE_PIE.updateCount(5), BANANA_MUFFIN, CHOCOCHIP,
                 DALGONA_COFFEE, EGGNOG, FOREST_CAKE, GRANOLA_BAR));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalItems.java
+++ b/src/test/java/seedu/address/testutil/TypicalItems.java
@@ -1,5 +1,8 @@
 package seedu.address.testutil;
 
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNT_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_DONUT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_DONUT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BAKED;
@@ -50,9 +53,9 @@ public class TypicalItems {
 
     // Manually added - Item's details found in {@code CommandTestUtil}
     public static final Item BAGEL = new ItemBuilder()
-            .withName(VALID_NAME_BAGEL).withCount("5").withId("123456").withTags(VALID_TAG_BAKED).build();
+            .withName(VALID_NAME_BAGEL).withCount(VALID_COUNT_BAGEL).withId(VALID_ID_BAGEL).withTags(VALID_TAG_BAKED).build();
     public static final Item DONUT = new ItemBuilder()
-            .withName(VALID_NAME_DONUT).withCount("5").withId("789012").withTags(VALID_TAG_BAKED, VALID_TAG_POPULAR)
+            .withName(VALID_NAME_DONUT).withCount(VALID_COUNT_BAGEL).withId(VALID_ID_DONUT).withTags(VALID_TAG_BAKED, VALID_TAG_POPULAR)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER

--- a/src/test/java/seedu/address/testutil/TypicalItems.java
+++ b/src/test/java/seedu/address/testutil/TypicalItems.java
@@ -53,9 +53,16 @@ public class TypicalItems {
 
     // Manually added - Item's details found in {@code CommandTestUtil}
     public static final Item BAGEL = new ItemBuilder()
-            .withName(VALID_NAME_BAGEL).withCount(VALID_COUNT_BAGEL).withId(VALID_ID_BAGEL).withTags(VALID_TAG_BAKED).build();
+            .withName(VALID_NAME_BAGEL)
+            .withCount(VALID_COUNT_BAGEL)
+            .withId(VALID_ID_BAGEL)
+            .withTags(VALID_TAG_BAKED)
+            .build();
     public static final Item DONUT = new ItemBuilder()
-            .withName(VALID_NAME_DONUT).withCount(VALID_COUNT_BAGEL).withId(VALID_ID_DONUT).withTags(VALID_TAG_BAKED, VALID_TAG_POPULAR)
+            .withName(VALID_NAME_DONUT)
+            .withCount(VALID_COUNT_BAGEL)
+            .withId(VALID_ID_DONUT)
+            .withTags(VALID_TAG_BAKED, VALID_TAG_POPULAR)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER


### PR DESCRIPTION
Fixes #40.

AB3 deletes items by specifying the index of them item. There is also no option to delete only some of the given item (e.g. 3 apples)

Let's have BogoBogo allow deleting by specifying either the name or id of the item. There needs to also be an option to delete a given amount of the item.

Miscellaneous edits:
   - Migrated ModelStub to a separate class for all tests to use. Removes the need for constant rebasing each time one of us adds a method to the Model interface.
   - Fixed `Item::equals` which failed to consider count of item