### PR TITLE
Add item descriptor

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -9,10 +9,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.Name;
 
+import java.util.List;
+
 /**
- * Adds a person to the address book.
+ * Adds an item to the inventory.
  */
 public class AddCommand extends Command {
 
@@ -20,57 +23,67 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds item(s) to the inventory. "
             + "Parameters: "
-            + PREFIX_NAME + "NAME "
+            + "NAME "
             + PREFIX_ID + "ID "
             + PREFIX_COUNT + "COUNT "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "Banana Bread "
+            + "Banana Bread "
             + PREFIX_ID + "019381 "
             + PREFIX_COUNT + "10 "
             + PREFIX_TAG + "baked "
             + PREFIX_TAG + "popular";
 
-    public static final String MESSAGE_SUCCESS = "New item added: %1$s";
-    public static final String MESSAGE_SUCCESS_REPLENISH = "Item replenished: %1$s";
-    public static final String MESSAGE_INCOMPLETE_INFO = "For first time adding, please provide both name and id";
+    public static final String MESSAGE_SUCCESS_NEW = "New item added: %1$s";
+    public static final String MESSAGE_SUCCESS_REPLENISH = "Item replenished: %dx %s";
+    public static final String MESSAGE_INCOMPLETE_INFO = "Item has not been added before, please provide both a name and id";
+    public static final String MESSAGE_MULTIPLE_MATCHES = "Multiple candidates found, which one did you mean to add?";
 
-    private final Item toAdd;
+    private final ItemDescriptor toAddDescriptor;
 
     /**
-     * Creates an AddCommand to add the specified {@code Item}
+     * Creates an AddCommand to add the Item specified by the {@code ItemDescriptor}
      */
-    public AddCommand(Item item) {
-        requireNonNull(item);
-        toAdd = item;
+    public AddCommand(ItemDescriptor itemDescriptor) {
+        requireNonNull(itemDescriptor);
+        toAddDescriptor = itemDescriptor;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasItem(toAdd)) {
-            Item inInventory = toAdd.getId() == "999999"
-                    ? model.getItemWithName(toAdd.getName().toString())
-                    : model.getItemWithId(toAdd.getId());
-            inInventory.replenishItem(toAdd.getCount());
-            model.setItem(inInventory, inInventory);
+        List<Item> matchingItems = model.getItems(toAddDescriptor);
 
-            return new CommandResult(String.format(MESSAGE_SUCCESS_REPLENISH, inInventory));
+        // Check if item exists in inventory
+        if (matchingItems.size() == 0) {
+            // Check name and id are specified
+            if (toAddDescriptor.getName().isEmpty() || toAddDescriptor.getId().isEmpty()) {
+                throw new CommandException(MESSAGE_INCOMPLETE_INFO);
+            }
+
+            // Add the new item into inventory
+            Item newItem = toAddDescriptor.buildItem();
+            model.addItem(newItem);
+            return new CommandResult(String.format(MESSAGE_SUCCESS_NEW, newItem));
         }
 
-        if (toAdd.getId() == "999999" || toAdd.getName().equals(new Name("dummy name"))) {
-            throw new CommandException(MESSAGE_INCOMPLETE_INFO);
+        // Check that only 1 item fit the description
+        if (matchingItems.size() > 1) {
+            model.updateFilteredItemList(toAddDescriptor::isMatch);
+            throw new CommandException(MESSAGE_MULTIPLE_MATCHES);
         }
 
-        model.addItem(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        Item target = matchingItems.get(0);
+        int amount = toAddDescriptor.getCount().get();
+        model.restockItem(target, toAddDescriptor.getCount().get());
+        return new CommandResult(String.format(MESSAGE_SUCCESS_REPLENISH, amount, target.getName()));
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AddCommand // instanceof handles nulls
-                && toAdd.equals(((AddCommand) other).toAdd));
+                && toAddDescriptor.equals(((AddCommand) other).toAddDescriptor));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -3,16 +3,14 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.List;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
-import seedu.address.model.item.Name;
-
-import java.util.List;
 
 /**
  * Adds an item to the inventory.
@@ -36,7 +34,8 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS_NEW = "New item added: %1$s";
     public static final String MESSAGE_SUCCESS_REPLENISH = "Item replenished: %dx %s";
-    public static final String MESSAGE_INCOMPLETE_INFO = "Item has not been added before, please provide both a name and id";
+    public static final String MESSAGE_INCOMPLETE_INFO = "Item has not been added before,"
+            + " please provide both a name and id";
     public static final String MESSAGE_MULTIPLE_MATCHES = "Multiple candidates found, which one did you mean to add?";
 
     private final ItemDescriptor toAddDescriptor;

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -18,7 +18,7 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds item(s) to the inventory. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_ID + "ID "
@@ -38,7 +38,7 @@ public class AddCommand extends Command {
     private final Item toAdd;
 
     /**
-     * Creates an AddCommand to add the specified {@code Person}
+     * Creates an AddCommand to add the specified {@code Item}
      */
     public AddCommand(Item item) {
         requireNonNull(item);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -7,18 +7,15 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.Name;
 import seedu.address.model.tag.Tag;
 
@@ -45,18 +42,18 @@ public class EditCommand extends Command {
     public static final String MESSAGE_DUPLICATE_ITEM = "This item already exists in the inventory.";
 
     private final Index index;
-    private final EditItemDescriptor editItemDescriptor;
+    private final ItemDescriptor itemDescriptor;
 
     /**
      * @param index of the item in the filtered item list to edit
-     * @param editItemDescriptor details to edit the item with
+     * @param itemDescriptor details to edit the item with
      */
-    public EditCommand(Index index, EditItemDescriptor editItemDescriptor) {
+    public EditCommand(Index index, ItemDescriptor itemDescriptor) {
         requireNonNull(index);
-        requireNonNull(editItemDescriptor);
+        requireNonNull(itemDescriptor);
 
         this.index = index;
-        this.editItemDescriptor = new EditItemDescriptor(editItemDescriptor);
+        this.itemDescriptor = new ItemDescriptor(itemDescriptor);
     }
 
     @Override
@@ -69,7 +66,7 @@ public class EditCommand extends Command {
         }
 
         Item itemToEdit = lastShownList.get(index.getZeroBased());
-        Item editedItem = createEditedItem(itemToEdit, editItemDescriptor);
+        Item editedItem = createEditedItem(itemToEdit, itemDescriptor);
 
         if (!itemToEdit.isSameItem(editedItem) && model.hasItem(editedItem)) {
             throw new CommandException(MESSAGE_DUPLICATE_ITEM);
@@ -82,15 +79,15 @@ public class EditCommand extends Command {
 
     /**
      * Creates and returns a {@code Item} with the details of {@code itemToEdit}
-     * edited with {@code editItemDescriptor}.
+     * edited with {@code itemDescriptor}.
      */
-    private static Item createEditedItem(Item itemToEdit, EditItemDescriptor editItemDescriptor) {
+    private static Item createEditedItem(Item itemToEdit, ItemDescriptor itemDescriptor) {
         assert itemToEdit != null;
 
-        Name updatedName = editItemDescriptor.getName().orElse(itemToEdit.getName());
-        String updatedId = editItemDescriptor.getId().orElse(itemToEdit.getId());
-        Integer updatedCount = editItemDescriptor.getCount().orElse(itemToEdit.getCount());
-        Set<Tag> updatedTags = editItemDescriptor.getTags().orElse(itemToEdit.getTags());
+        Name updatedName = itemDescriptor.getName().orElse(itemToEdit.getName());
+        String updatedId = itemDescriptor.getId().orElse(itemToEdit.getId());
+        Integer updatedCount = itemDescriptor.getCount().orElse(itemToEdit.getCount());
+        Set<Tag> updatedTags = itemDescriptor.getTags().orElse(itemToEdit.getTags());
 
         return new Item(updatedName, updatedId, updatedCount, updatedTags);
     }
@@ -110,98 +107,7 @@ public class EditCommand extends Command {
         // state check
         EditCommand e = (EditCommand) other;
         return index.equals(e.index)
-                && editItemDescriptor.equals(e.editItemDescriptor);
+                && itemDescriptor.equals(e.itemDescriptor);
     }
 
-    /**
-     * Stores the details to edit the item with. Each non-empty field value will replace the
-     * corresponding field value of the item.
-     */
-    public static class EditItemDescriptor {
-        private Name name;
-        private String id;
-        private Set<Tag> tags;
-        private Integer count;
-
-        public EditItemDescriptor() {}
-
-        /**
-         * Copy constructor.
-         * A defensive copy of {@code tags} is used internally.
-         */
-        public EditItemDescriptor(EditItemDescriptor toCopy) {
-            setName(toCopy.name);
-            setId(toCopy.id);
-            setCount(toCopy.count);
-            setTags(toCopy.tags);
-        }
-
-        /**
-         * Returns true if at least one field is edited.
-         */
-        public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, id, tags);
-        }
-
-        public void setName(Name name) {
-            this.name = name;
-        }
-
-        public Optional<Name> getName() {
-            return Optional.ofNullable(name);
-        }
-
-        public void setId(String id) {
-            this.id = id;
-        }
-
-        public Optional<String> getId() {
-            return Optional.ofNullable(id);
-        }
-
-        public void setCount(Integer count) {
-            this.count = count;
-        }
-
-        public Optional<Integer> getCount() {
-            return Optional.ofNullable(count);
-        }
-
-        /**
-         * Sets {@code tags} to this object's {@code tags}.
-         * A defensive copy of {@code tags} is used internally.
-         */
-        public void setTags(Set<Tag> tags) {
-            this.tags = (tags != null) ? new HashSet<>(tags) : null;
-        }
-
-        /**
-         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
-         * if modification is attempted.
-         * Returns {@code Optional#empty()} if {@code tags} is null.
-         */
-        public Optional<Set<Tag>> getTags() {
-            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            // short circuit if same object
-            if (other == this) {
-                return true;
-            }
-
-            // instanceof handles nulls
-            if (!(other instanceof EditItemDescriptor)) {
-                return false;
-            }
-
-            // state check
-            EditItemDescriptor e = (EditItemDescriptor) other;
-
-            return getName().equals(e.getName())
-                    && getId().equals(e.getId())
-                    && getTags().equals(e.getTags());
-        }
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -3,17 +3,11 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-
-import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.item.Item;
-import seedu.address.model.item.Name;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.item.ItemDescriptor;
 
 /**
  * Parses input arguments and creates a new AddCommand object
@@ -27,35 +21,34 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ID, PREFIX_COUNT, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_COUNT, PREFIX_TAG);
 
-        if ((!arePrefixesPresent(argMultimap, PREFIX_NAME) && !arePrefixesPresent(argMultimap, PREFIX_ID))
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (argMultimap.getValue(PREFIX_ID).isEmpty() && argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        Name name = arePrefixesPresent(argMultimap, PREFIX_NAME)
-                ? ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get())
-                : new Name("dummy name");
-        String id = arePrefixesPresent(argMultimap, PREFIX_ID)
-                ? ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get())
-                : "999999";
-        Integer count = arePrefixesPresent(argMultimap, PREFIX_COUNT)
-                ? ParserUtil.parseCount(argMultimap.getValue(PREFIX_COUNT).get())
-                : 1;
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        ItemDescriptor toAddDescriptor = new ItemDescriptor();
 
-        Item item = new Item(name, id, count, tagList);
+        // Parse name
+        if (!argMultimap.getPreamble().isEmpty()) {
+            toAddDescriptor.setName(ParserUtil.parseName(argMultimap.getPreamble()));
+        }
+        // Parse Id
+        if (argMultimap.getValue(PREFIX_ID).isPresent()) {
+            toAddDescriptor.setId(ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get()));
+        }
+        // Parse count
+        if (argMultimap.getValue(PREFIX_COUNT).isPresent()) {
+            toAddDescriptor.setCount(ParserUtil.parseCount(argMultimap.getValue(PREFIX_COUNT).get()));
+        } else {
+            toAddDescriptor.setCount(1);
+        }
+        // Parse tags
+        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            toAddDescriptor.setTags(ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG)));
+        }
 
-        return new AddCommand(item);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+        return new AddCommand(toAddDescriptor);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -13,8 +13,8 @@ import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditCommand.EditItemDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -40,20 +40,20 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
-        EditItemDescriptor editPersonDescriptor = new EditItemDescriptor();
+        ItemDescriptor itemDescriptor = new ItemDescriptor();
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+            itemDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_ID).isPresent()) {
-            editPersonDescriptor.setId(ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get()));
+            itemDescriptor.setId(ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(itemDescriptor::setTags);
 
-        if (!editPersonDescriptor.isAnyFieldEdited()) {
+        if (!itemDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new EditCommand(index, editPersonDescriptor);
+        return new EditCommand(index, itemDescriptor);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -30,7 +31,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ID, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ID, PREFIX_COUNT, PREFIX_TAG);
 
         Index index;
 
@@ -46,6 +47,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_ID).isPresent()) {
             itemDescriptor.setId(ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get()));
+        }
+        if (argMultimap.getValue(PREFIX_COUNT).isPresent()) {
+            itemDescriptor.setCount(ParserUtil.parseCount(argMultimap.getValue(PREFIX_COUNT).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(itemDescriptor::setTags);
 

--- a/src/main/java/seedu/address/model/Inventory.java
+++ b/src/main/java/seedu/address/model/Inventory.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.Name;
 import seedu.address.model.item.UniqueItemList;
 
@@ -84,6 +85,15 @@ public class Inventory implements ReadOnlyInventory {
     public boolean hasItem(String id) {
         requireNonNull(id);
         return items.contains(id);
+    }
+
+    /**
+     * Returns list of items in the inventory that matches the given {@code ItemDescriptor}
+     * @see ItemDescriptor#isMatch(Item)
+     */
+    public List<Item> getItems(ItemDescriptor descriptor) {
+        requireNonNull(descriptor);
+        return items.get(descriptor);
     }
 
     /**
@@ -192,6 +202,17 @@ public class Inventory implements ReadOnlyInventory {
         requireNonNull(editedItem);
 
         items.setItem(target, editedItem);
+    }
+
+    /**
+     * Increments the count of the given item {@code target} by {@code amount}.
+     * {@code target} must exist in the inventory.
+     */
+    public void restockItem(Item target, int amount) {
+        requireNonNull(target);
+
+        Item newItem = target.updateCount(target.getCount() + amount);
+        items.setItem(target, newItem);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -68,15 +68,15 @@ public interface Model {
     boolean hasItem(Name name);
 
     /**
-     * Returns list of items in the inventory that matches the given {@code ItemDescriptor}
-     */
-    List<Item> getItems(ItemDescriptor descriptor);
-
-    /**
      * Returns true if an item with the given {@code id} exists in the inventory.
      * @see ItemDescriptor#isMatch(Item)
      */
     boolean hasItem(String id);
+
+    /**
+     * Returns list of items in the inventory that matches the given {@code ItemDescriptor}
+     */
+    List<Item> getItems(ItemDescriptor descriptor);
 
     /**
      * Deletes item in the inventory with the given name.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -2,11 +2,13 @@ package seedu.address.model;
 
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.Name;
 
 /**
@@ -66,7 +68,13 @@ public interface Model {
     boolean hasItem(Name name);
 
     /**
+     * Returns list of items in the inventory that matches the given {@code ItemDescriptor}
+     */
+    List<Item> getItems(ItemDescriptor descriptor);
+
+    /**
      * Returns true if an item with the given {@code id} exists in the inventory.
+     * @see ItemDescriptor#isMatch(Item)
      */
     boolean hasItem(String id);
 
@@ -89,8 +97,7 @@ public interface Model {
     Item deleteItem(String id, int count);
 
     /**
-     * Adds the given item.
-     * If {@code item} must not already exist in the address book, increment its count accordingly.
+     * Adds the given item into inventory
      */
     void addItem(Item item);
 
@@ -100,6 +107,12 @@ public interface Model {
      * The item identity of {@code editedItem} must not be the same as another existing item in the inventory.
      */
     void setItem(Item target, Item editedItem);
+
+    /**
+     * Increments the count of the given item {@code target} with {@code amount}.
+     * {@code target} must exist in the inventory.
+     */
+    void restockItem(Item target, int amount);
 
     /**
      * Sorts the item list using the given {@code comparator}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -14,6 +15,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.Name;
 
 /**
@@ -112,6 +114,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public List<Item> getItems(ItemDescriptor descriptor) {
+        requireNonNull(descriptor);
+        return inventory.getItems(descriptor);
+    }
+
+    @Override
     public Item deleteItem(Name name, int count) {
         return inventory.removeItem(name, count);
     }
@@ -132,6 +140,12 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedItem);
 
         inventory.setItem(target, editedItem);
+    }
+
+    @Override
+    public void restockItem(Item target, int amount) {
+        requireNonNull(target);
+        inventory.restockItem(target, amount);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/item/ItemDescriptor.java
+++ b/src/main/java/seedu/address/model/item/ItemDescriptor.java
@@ -1,7 +1,6 @@
 package seedu.address.model.item;
 
 import seedu.address.commons.util.CollectionUtil;
-import seedu.address.logic.commands.EditCommand;
 import seedu.address.model.tag.Tag;
 
 import java.util.Collections;
@@ -14,6 +13,7 @@ import java.util.Set;
  * Utilised by logic like {@code AddCommand}, {@code EditCommand} to partially describe items.
  */
 public class ItemDescriptor {
+
     private Name name;
     private String id;
     private Set<Tag> tags;
@@ -79,6 +79,39 @@ public class ItemDescriptor {
      */
     public Optional<Set<Tag>> getTags() {
         return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+    }
+
+    /**
+     * Returns true if the given {@code item} has the same name or id as the descriptor.
+     */
+    public boolean isMatch(Item item) {
+        // Return true if name matches
+        if (name != null && name.equals(item.getName())) {
+            return true;
+        }
+        // Return true if id matches
+        if (id != null && id.equals(item.getId())) {
+            return true;
+        }
+        // Return false otherwise
+        return false;
+    }
+
+    /**
+     * Returns the corresponding {@code Item}.
+     * If count unspecified, defaults to 1.
+     * @throws NullPointerException if either name or id is unspecified.
+     *
+     */
+    public Item buildItem() {
+        if (name == null || id == null) {
+            throw new NullPointerException("Item descriptor requires both name and id to build");
+        }
+
+        int itemCount = (count == null) ? 1 : count;
+        Set<Tag> itemTags = (tags == null) ? new HashSet<>() : tags;
+
+        return new Item(name, id, itemCount, itemTags);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/item/ItemDescriptor.java
+++ b/src/main/java/seedu/address/model/item/ItemDescriptor.java
@@ -1,12 +1,12 @@
 package seedu.address.model.item;
 
-import seedu.address.commons.util.CollectionUtil;
-import seedu.address.model.tag.Tag;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.model.tag.Tag;
 
 /**
  * Stores the partial details of an item. Unlike {@code Item}, fields can be null value.

--- a/src/main/java/seedu/address/model/item/ItemDescriptor.java
+++ b/src/main/java/seedu/address/model/item/ItemDescriptor.java
@@ -1,0 +1,104 @@
+package seedu.address.model.item;
+
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.model.tag.Tag;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Stores the partial details of an item. Unlike {@code Item}, fields can be null value.
+ * Utilised by logic like {@code AddCommand}, {@code EditCommand} to partially describe items.
+ */
+public class ItemDescriptor {
+    private Name name;
+    private String id;
+    private Set<Tag> tags;
+    private Integer count;
+
+    public ItemDescriptor() {
+    }
+
+    /**
+     * Copy constructor.
+     * A defensive copy of {@code tags} is used internally.
+     */
+    public ItemDescriptor(ItemDescriptor toCopy) {
+        setName(toCopy.name);
+        setId(toCopy.id);
+        setCount(toCopy.count);
+        setTags(toCopy.tags);
+    }
+
+    /**
+     * Returns true if at least one field is edited.
+     */
+    public boolean isAnyFieldEdited() {
+        return CollectionUtil.isAnyNonNull(name, id, tags);
+    }
+
+    public void setName(Name name) {
+        this.name = name;
+    }
+
+    public Optional<Name> getName() {
+        return Optional.ofNullable(name);
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Optional<String> getId() {
+        return Optional.ofNullable(id);
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    public Optional<Integer> getCount() {
+        return Optional.ofNullable(count);
+    }
+
+    /**
+     * Sets {@code tags} to this object's {@code tags}.
+     * A defensive copy of {@code tags} is used internally.
+     */
+    public void setTags(Set<Tag> tags) {
+        this.tags = (tags != null) ? new HashSet<>(tags) : null;
+    }
+
+    /**
+     * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     * Returns {@code Optional#empty()} if {@code tags} is null.
+     */
+    public Optional<Set<Tag>> getTags() {
+        return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ItemDescriptor)) {
+            return false;
+        }
+
+        // state check
+        ItemDescriptor e = (ItemDescriptor) other;
+
+        return getName().equals(e.getName())
+                && getId().equals(e.getId())
+                && getCount().equals(e.getCount())
+                && getTags().equals(e.getTags());
+    }
+}

--- a/src/main/java/seedu/address/model/item/UniqueItemList.java
+++ b/src/main/java/seedu/address/model/item/UniqueItemList.java
@@ -7,6 +7,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -53,6 +54,16 @@ public class UniqueItemList implements Iterable<Item> {
     public boolean contains(String id) {
         requireNonNull(id);
         return internalList.stream().anyMatch(item -> id.equals(item.getId()));
+    }
+
+    /**
+     * Returns true if the list contains an item that matches the given {@code ItemDescriptor}
+     */
+    public List<Item> get(ItemDescriptor descriptor) {
+        requireNonNull(descriptor);
+        return internalList.stream()
+                .filter(descriptor::isMatch)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BAGEL;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalItems.BAGEL;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalItems.BAGEL;
 
@@ -78,7 +79,7 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Execute add command
-        String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL;
+        String addCommand = AddCommand.COMMAND_WORD + " " + VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL;
         Item expectedItem = new ItemBuilder(BAGEL).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addItem(expectedItem);

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -18,8 +18,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
-import seedu.address.testutil.ItemDescriptorBuilder;
 import seedu.address.testutil.ItemBuilder;
+import seedu.address.testutil.ItemDescriptorBuilder;
 
 public class AddCommandIntegrationTest {
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -27,8 +27,8 @@ import seedu.address.model.ModelStub;
 import seedu.address.model.ReadOnlyInventory;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
-import seedu.address.testutil.ItemDescriptorBuilder;
 import seedu.address.testutil.ItemBuilder;
+import seedu.address.testutil.ItemDescriptorBuilder;
 
 public class AddCommandTest {
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -4,20 +4,35 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNT_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BAKED;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_POPULAR;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalItems.BAGEL;
+import static seedu.address.testutil.TypicalItems.DONUT;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Inventory;
 import seedu.address.model.ModelStub;
 import seedu.address.model.ReadOnlyInventory;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
+import seedu.address.testutil.ItemDescriptorBuilder;
 import seedu.address.testutil.ItemBuilder;
 
 public class AddCommandTest {
+
+    private ModelStubAcceptingItemAdded modelStub = new ModelStubAcceptingItemAdded();
 
     @Test
     public void constructor_nullItem_throwsNullPointerException() {
@@ -25,33 +40,107 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_itemAcceptedByModel_addSuccessful() throws Exception {
-        ModelStubAcceptingItemAdded modelStub = new ModelStubAcceptingItemAdded();
-        Item validItem = new ItemBuilder().build();
+    public void execute_newItem_addSuccessful() throws Exception {
+        ItemDescriptor validDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .withId(VALID_ID_BAGEL)
+                .withTags(VALID_TAG_BAKED, VALID_TAG_POPULAR)
+                .withCount(VALID_COUNT_BAGEL)
+                .build();
 
-        CommandResult commandResult = new AddCommand(validItem).execute(modelStub);
+        Item validItem = new ItemBuilder(BAGEL)
+                .withTags(VALID_TAG_BAKED, VALID_TAG_POPULAR)
+                .build();
 
-        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validItem), commandResult.getFeedbackToUser());
-        assertEquals(Arrays.asList(validItem), modelStub.itemsAdded);
+        CommandResult commandResult = new AddCommand(validDescriptor).execute(modelStub);
+        ModelStubAcceptingItemAdded expectedModel = new ModelStubAcceptingItemAdded();
+        expectedModel.addItem(validItem);
+
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS_NEW, validItem), commandResult.getFeedbackToUser());
+        assertEquals(modelStub, expectedModel);
     }
 
-    //    @Test
-    //    public void execute_duplicateItem() throws CommandException {
-    //        ModelStub modelStub = new ModelStub();
-    //        Item validItem = new ItemBuilder().build();
-    //        AddCommand addCommand = new AddCommand(validItem);
-    //
-    //        Item validItemDouble = new ItemBuilder().withCount("10").build();
-    //        ModelStub modelStub2 = new ModelStubWithItem(validItemDouble);
-    //
-    //        addCommand.execute(modelStub);
-    //    }
-    // TODO: Guys pls help i have no idea how to do the test for this
+    @Test
+    public void execute_newItemNoId_incompleteInfofailure() {
+        ItemDescriptor validDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .withCount(VALID_COUNT_BAGEL)
+                .build();
+
+        AddCommand addCommand = new AddCommand(validDescriptor);
+
+        assertThrows(CommandException.class, AddCommand.MESSAGE_INCOMPLETE_INFO, () -> addCommand.execute(modelStub));
+    }
+
+    @Test
+    public void execute_newItemNoName_incompleteInfofailure() {
+        ItemDescriptor validDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .build();
+
+        AddCommand addCommand = new AddCommand(validDescriptor);
+
+        assertThrows(CommandException.class, AddCommand.MESSAGE_INCOMPLETE_INFO, () -> addCommand.execute(modelStub));
+    }
+
+    @Test
+    public void execute_existingItemNameDescription_restockSuccessful() {
+        modelStub.addItem(BAGEL.updateCount(5));
+
+        ItemDescriptor validDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .withCount(5)
+                .build();
+
+        AddCommand addCommand = new AddCommand(validDescriptor);
+
+        String expectedMessage = String.format(AddCommand.MESSAGE_SUCCESS_REPLENISH, 5, VALID_NAME_BAGEL);
+        ModelStubAcceptingItemAdded expectedModel = new ModelStubAcceptingItemAdded();
+        expectedModel.addItem(BAGEL);
+        expectedModel.restockItem(BAGEL, 5);
+
+        assertCommandSuccess(addCommand, modelStub, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_existingItemIdDescription_restockSuccessful() {
+        modelStub.addItem(BAGEL);
+
+        ItemDescriptor validDescriptor = new ItemDescriptorBuilder()
+                .withId(VALID_ID_BAGEL)
+                .withCount(5)
+                .build();
+
+        AddCommand addCommand = new AddCommand(validDescriptor);
+
+        String expectedMessage = String.format(AddCommand.MESSAGE_SUCCESS_REPLENISH, 5, VALID_NAME_BAGEL);
+        ModelStubAcceptingItemAdded expectedModel = new ModelStubAcceptingItemAdded();
+        expectedModel.addItem(BAGEL);
+        expectedModel.restockItem(BAGEL, 5);
+
+        assertCommandSuccess(addCommand, modelStub, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_multipleMatches_failure() {
+        modelStub.addItem(BAGEL);
+        modelStub.addItem(DONUT);
+
+        ItemDescriptor validDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_DONUT)
+                .withId(VALID_ID_BAGEL)
+                .withCount(5)
+                .build();
+
+        AddCommand addCommand = new AddCommand(validDescriptor);
+
+        assertThrows(CommandException.class, AddCommand.MESSAGE_MULTIPLE_MATCHES, () -> addCommand.execute(modelStub));
+    }
 
     @Test
     public void equals() {
-        Item bagel = new ItemBuilder().withName("Bagel").build();
-        Item donut = new ItemBuilder().withName("Donut").build();
+        ItemDescriptor bagel = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
+        ItemDescriptor donut = new ItemDescriptorBuilder().withName(VALID_NAME_DONUT).build();
         AddCommand addBagelCommand = new AddCommand(bagel);
         AddCommand addDonutCommand = new AddCommand(donut);
 
@@ -73,28 +162,14 @@ public class AddCommandTest {
     }
 
     /**
-     * A Model stub that contains a single item.
-     */
-    private class ModelStubWithItem extends ModelStub {
-        private final Item item;
-
-        ModelStubWithItem(Item item) {
-            requireNonNull(item);
-            this.item = item;
-        }
-
-        @Override
-        public boolean hasItem(Item item) {
-            requireNonNull(item);
-            return this.item.isSameItem(item);
-        }
-    }
-
-    /**
-     * A Model stub that always accept the item being added.
+     * A Model stub that always accept the item being added. Assumed to only be able to hold one item.
+     * Naively supports restocking items and getting items.
+     * When {@code getItems} is called, return entire list.
      */
     private class ModelStubAcceptingItemAdded extends ModelStub {
         final ArrayList<Item> itemsAdded = new ArrayList<>();
+
+        private int addedAmount = 0;
 
         @Override
         public boolean hasItem(Item item) {
@@ -109,8 +184,40 @@ public class AddCommandTest {
         }
 
         @Override
+        public void restockItem(Item item, int amount) {
+            requireNonNull(item);
+            addedAmount = amount;
+        }
+
+        @Override
+        public List<Item> getItems(ItemDescriptor itemDescriptor) {
+            return itemsAdded;
+        }
+
+        @Override
+        public void updateFilteredItemList(Predicate<Item> predicate) {
+        }
+
+        @Override
         public ReadOnlyInventory getInventory() {
             return new Inventory();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            // short circuit if same object
+            if (obj == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(obj instanceof ModelStubAcceptingItemAdded)) {
+                return false;
+            }
+
+            // state check
+            ModelStubAcceptingItemAdded other = (ModelStubAcceptingItemAdded) obj;
+            return itemsAdded.equals(other.itemsAdded) && addedAmount == other.addedAmount;
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -10,7 +10,9 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -19,6 +21,7 @@ import seedu.address.model.Model;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.NameContainsKeywordsPredicate;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.ItemDescriptorBuilder;
 
 /**
@@ -33,6 +36,7 @@ public class CommandTestUtil {
     public static final String VALID_ID_BAGEL = "123456";
     public static final String VALID_ID_DONUT = "789012";
     public static final String VALID_COUNT_BAGEL = "5";
+    public static final String VALID_COUNT_DONUT = "6";
     public static final String VALID_TAG_BAKED = "baked";
     public static final String VALID_TAG_POPULAR = "popular";
 
@@ -41,10 +45,12 @@ public class CommandTestUtil {
     public static final String ID_DESC_BAGEL = " " + PREFIX_ID + VALID_ID_BAGEL;
     public static final String ID_DESC_DONUT = " " + PREFIX_ID + VALID_ID_DONUT;
     public static final String COUNT_DESC_BAGEL = " " + PREFIX_COUNT + VALID_COUNT_BAGEL;
+    public static final String COUNT_DESC_DONUT = " " + PREFIX_COUNT + VALID_COUNT_DONUT;
     public static final String TAG_DESC_BAKED = " " + PREFIX_TAG + VALID_TAG_BAKED;
     public static final String TAG_DESC_POPULAR = " " + PREFIX_TAG + VALID_TAG_POPULAR;
 
-    public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "Cake&"; // '&' not allowed in names
+    public static final String INVALID_NAME = "Cake$";
+    public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + INVALID_NAME; // '&' not allowed in names
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
     public static final String INVALID_ID_BAGEL = " " + PREFIX_ID + "231";
     public static final String INVALID_ID_BAGEL_2 = " " + PREFIX_ID + "-123232";

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -10,9 +10,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -21,7 +19,6 @@ import seedu.address.model.Model;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.NameContainsKeywordsPredicate;
-import seedu.address.model.tag.Tag;
 import seedu.address.testutil.ItemDescriptorBuilder;
 
 /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -17,8 +17,9 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Inventory;
 import seedu.address.model.Model;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.NameContainsKeywordsPredicate;
-import seedu.address.testutil.EditItemDescriptorBuilder;
+import seedu.address.testutil.ItemDescriptorBuilder;
 
 /**
  * Contains helper methods for testing commands.
@@ -53,13 +54,13 @@ public class CommandTestUtil {
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
-    public static final EditCommand.EditItemDescriptor DESC_BAGEL;
-    public static final EditCommand.EditItemDescriptor DESC_DONUT;
+    public static final ItemDescriptor DESC_BAGEL;
+    public static final ItemDescriptor DESC_DONUT;
 
     static {
-        DESC_BAGEL = new EditItemDescriptorBuilder().withName(VALID_NAME_BAGEL)
+        DESC_BAGEL = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL)
                 .withId(VALID_ID_BAGEL).withCount(VALID_COUNT_BAGEL).withTags(VALID_TAG_BAKED).build();
-        DESC_DONUT = new EditItemDescriptorBuilder().withName(VALID_NAME_DONUT)
+        DESC_DONUT = new ItemDescriptorBuilder().withName(VALID_NAME_DONUT)
                 .withId(VALID_ID_DONUT).withCount(VALID_COUNT_BAGEL)
                 .withTags(VALID_TAG_BAKED, VALID_TAG_POPULAR).build();
     }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -17,13 +17,13 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.EditCommand.EditItemDescriptor;
 import seedu.address.model.Inventory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.item.Item;
-import seedu.address.testutil.EditItemDescriptorBuilder;
+import seedu.address.model.item.ItemDescriptor;
+import seedu.address.testutil.ItemDescriptorBuilder;
 import seedu.address.testutil.ItemBuilder;
 
 /**
@@ -56,7 +56,7 @@ public class EditCommandTest {
         ItemBuilder itemInList = new ItemBuilder(lastItem);
         Item editedItem = itemInList.withName(VALID_NAME_DONUT).withTags(VALID_TAG_BAKED).build();
 
-        EditItemDescriptor descriptor = new EditItemDescriptorBuilder().withName(VALID_NAME_DONUT)
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_DONUT)
                 .withTags(VALID_TAG_BAKED).build();
         EditCommand editCommand = new EditCommand(indexLastItem, descriptor);
 
@@ -70,7 +70,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM, new EditItemDescriptor());
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM, new ItemDescriptor());
         Item editedItem = model.getFilteredItemList().get(INDEX_FIRST_ITEM.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_ITEM_SUCCESS, editedItem);
@@ -87,7 +87,7 @@ public class EditCommandTest {
         Item itemInFilteredList = model.getFilteredItemList().get(INDEX_FIRST_ITEM.getZeroBased());
         Item editedItem = new ItemBuilder(itemInFilteredList).withName(VALID_NAME_DONUT).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM,
-                new EditItemDescriptorBuilder().withName(VALID_NAME_DONUT).build());
+                new ItemDescriptorBuilder().withName(VALID_NAME_DONUT).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_ITEM_SUCCESS, editedItem);
 
@@ -100,7 +100,7 @@ public class EditCommandTest {
     @Test
     public void execute_duplicateItemUnfilteredList_failure() {
         Item firstItem = model.getFilteredItemList().get(INDEX_FIRST_ITEM.getZeroBased());
-        EditItemDescriptor descriptor = new EditItemDescriptorBuilder(firstItem).build();
+        ItemDescriptor descriptor = new ItemDescriptorBuilder(firstItem).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_ITEM, descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_ITEM);
@@ -113,7 +113,7 @@ public class EditCommandTest {
         // edit item in filtered list into a duplicate in inventory
         Item itemInList = model.getInventory().getItemList().get(INDEX_SECOND_ITEM.getZeroBased());
         EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM,
-                new EditItemDescriptorBuilder(itemInList).build());
+                new ItemDescriptorBuilder(itemInList).build());
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_ITEM);
     }
@@ -121,7 +121,7 @@ public class EditCommandTest {
     @Test
     public void execute_invalidItemIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredItemList().size() + 1);
-        EditItemDescriptor descriptor = new EditItemDescriptorBuilder().withName(VALID_NAME_DONUT).build();
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_DONUT).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);
@@ -139,7 +139,7 @@ public class EditCommandTest {
         assertTrue(outOfBoundIndex.getZeroBased() < model.getInventory().getItemList().size());
 
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
-                new EditItemDescriptorBuilder().withName(VALID_NAME_DONUT).build());
+                new ItemDescriptorBuilder().withName(VALID_NAME_DONUT).build());
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);
     }
@@ -149,7 +149,7 @@ public class EditCommandTest {
         final EditCommand standardCommand = new EditCommand(INDEX_FIRST_ITEM, DESC_BAGEL);
 
         // same values -> returns true
-        EditItemDescriptor copyDescriptor = new EditItemDescriptor(DESC_BAGEL);
+        ItemDescriptor copyDescriptor = new ItemDescriptor(DESC_BAGEL);
         EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_ITEM, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -23,8 +23,8 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
-import seedu.address.testutil.ItemDescriptorBuilder;
 import seedu.address.testutil.ItemBuilder;
+import seedu.address.testutil.ItemDescriptorBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -2,20 +2,19 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_DONUT;
 import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_DONUT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_COUNT_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_COUNT_VALUE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ID_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ID_BAGEL_2;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BAGEL;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_DONUT;
-import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
-import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_BAKED;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_POPULAR;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNT_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BAKED;
@@ -28,54 +27,86 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.Name;
 import seedu.address.model.tag.Tag;
-import seedu.address.testutil.ItemBuilder;
+import seedu.address.testutil.ItemDescriptorBuilder;
 
 public class AddCommandParserTest {
     private AddCommandParser parser = new AddCommandParser();
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Item expectedItem = new ItemBuilder(BAGEL).withTags(VALID_TAG_BAKED).build();
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder(BAGEL).withTags(VALID_TAG_BAKED).build();
 
-        // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL
-                + TAG_DESC_BAKED, new AddCommand(expectedItem));
-
-        // multiple names - last name accepted
-        assertParseSuccess(parser, NAME_DESC_DONUT + NAME_DESC_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL
-                + TAG_DESC_BAKED, new AddCommand(expectedItem));
+        // All fields
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL
+                + TAG_DESC_BAKED, new AddCommand(expectedDescriptor));
 
         // multiple id - last id accepted
-        assertParseSuccess(parser, NAME_DESC_BAGEL + ID_DESC_DONUT + ID_DESC_BAGEL + COUNT_DESC_BAGEL
-                + TAG_DESC_BAKED, new AddCommand(expectedItem));
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_DONUT + ID_DESC_BAGEL + COUNT_DESC_BAGEL
+                + TAG_DESC_BAKED, new AddCommand(expectedDescriptor));
+
+        // multiple count - last count accepted
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_DONUT + COUNT_DESC_BAGEL
+                + TAG_DESC_BAKED, new AddCommand(expectedDescriptor));
 
         // multiple tags - all accepted
-        Item expectedItemMultipleTags = new ItemBuilder(BAGEL).withTags(VALID_TAG_POPULAR, VALID_TAG_BAKED)
+        ItemDescriptor multipleTagsDescriptor =
+                new ItemDescriptorBuilder(BAGEL).withTags(VALID_TAG_POPULAR, VALID_TAG_BAKED).build();
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL
+                + TAG_DESC_POPULAR + TAG_DESC_BAKED, new AddCommand(multipleTagsDescriptor));
+    }
+
+    @Test
+    public void parse_nameOnlyNoId_success() {
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .withCount(VALID_COUNT_BAGEL)
                 .build();
-        assertParseSuccess(parser, NAME_DESC_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL
-                + TAG_DESC_POPULAR + TAG_DESC_BAKED, new AddCommand(expectedItemMultipleTags));
+
+        assertParseSuccess(parser, VALID_NAME_BAGEL + COUNT_DESC_BAGEL,
+                new AddCommand(expectedDescriptor));
+    }
+
+    @Test
+    public void parse_idOnlyNoName_success() {
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withId(VALID_ID_BAGEL)
+                .withCount(VALID_COUNT_BAGEL)
+                .build();
+
+        assertParseSuccess(parser, ID_DESC_BAGEL + COUNT_DESC_BAGEL,
+                new AddCommand(expectedDescriptor));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
-        // zero tags
-        Item expectedItem = new ItemBuilder(BAGEL).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL,
-                new AddCommand(expectedItem));
+
+        // zero tags;
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .withId(VALID_ID_BAGEL)
+                .withCount(VALID_COUNT_BAGEL)
+                .build();
+
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL,
+                new AddCommand(expectedDescriptor));
+
+        // no count (count should be defaulted to 1)
+        expectedDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .withId(VALID_ID_BAGEL)
+                .withCount(1)
+                .build();
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL,
+                new AddCommand(expectedDescriptor));
+
     }
 
     @Test
-    public void parse_compulsoryFieldMissing_failure() {
+    public void parse_noNameNorId_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
-
-        // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL, expectedMessage);
-
-        // count prefix missing
-        assertParseFailure(parser, VALID_NAME_BAGEL + VALID_ID_BAGEL, expectedMessage);
 
         // both name and id prefix missing
         assertParseFailure(parser, COUNT_DESC_BAGEL, expectedMessage);
@@ -84,36 +115,31 @@ public class AddCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + ID_DESC_BAGEL + COUNT_DESC_BAGEL
+        assertParseFailure(parser, INVALID_NAME + ID_DESC_BAGEL + COUNT_DESC_BAGEL
                 + TAG_DESC_POPULAR + TAG_DESC_BAKED, Name.MESSAGE_CONSTRAINTS);
 
         // invalid id with negative number
-        assertParseFailure(parser, NAME_DESC_BAGEL + INVALID_ID_BAGEL_2 + COUNT_DESC_BAGEL
+        assertParseFailure(parser, VALID_NAME_BAGEL + INVALID_ID_BAGEL_2 + COUNT_DESC_BAGEL
                 + TAG_DESC_POPULAR + TAG_DESC_BAKED, Messages.MESSAGE_INVALID_ID_LENGTH_AND_SIGN);
 
         // invalid id with 3 numbers
-        assertParseFailure(parser, NAME_DESC_BAGEL + INVALID_ID_BAGEL + COUNT_DESC_BAGEL
+        assertParseFailure(parser, VALID_NAME_BAGEL + INVALID_ID_BAGEL + COUNT_DESC_BAGEL
                 + TAG_DESC_POPULAR + TAG_DESC_BAKED, Messages.MESSAGE_INVALID_ID_LENGTH_AND_SIGN);
 
         // invalid tag
-        assertParseFailure(parser, NAME_DESC_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL
+        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL
                 + INVALID_TAG_DESC + VALID_TAG_BAKED, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + ID_DESC_BAGEL + COUNT_DESC_BAGEL
+        assertParseFailure(parser, INVALID_NAME + ID_DESC_BAGEL + COUNT_DESC_BAGEL
                 + INVALID_TAG_DESC, Name.MESSAGE_CONSTRAINTS);
 
-        // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL
-                + TAG_DESC_BAKED + TAG_DESC_POPULAR,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-
         // invalid count format
-        assertParseFailure(parser, NAME_DESC_BAGEL + ID_DESC_BAGEL + INVALID_COUNT_FORMAT + TAG_DESC_BAKED,
+        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + INVALID_COUNT_FORMAT + TAG_DESC_BAKED,
                 Messages.MESSAGE_INVALID_COUNT_FORMAT);
 
         // invalid count value
-        assertParseFailure(parser, NAME_DESC_BAGEL + ID_DESC_BAGEL + INVALID_COUNT_VALUE + TAG_DESC_BAKED,
+        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + INVALID_COUNT_VALUE + TAG_DESC_BAKED,
                 Messages.MESSAGE_INVALID_COUNT_INTEGER);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -11,7 +11,6 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_ID_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ID_BAGEL_2;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_BAKED;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_POPULAR;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNT_BAGEL;

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -10,7 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -30,8 +29,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.NameContainsKeywordsPredicate;
-import seedu.address.testutil.ItemDescriptorBuilder;
 import seedu.address.testutil.ItemBuilder;
+import seedu.address.testutil.ItemDescriptorBuilder;
 import seedu.address.testutil.ItemUtil;
 
 public class AddressBookParserTest {
@@ -43,7 +42,7 @@ public class AddressBookParserTest {
         ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
         AddCommand command = (AddCommand) parser.parseCommand(ItemUtil.getAddCommand(descriptor));
 
-        descriptor.setCount(1);  // Parser should set descriptor count to 1
+        descriptor.setCount(1); // Parser should set descriptor count to 1
         assertEquals(new AddCommand(descriptor), command);
     }
 
@@ -65,12 +64,9 @@ public class AddressBookParserTest {
         Item item = new ItemBuilder().build();
         ItemDescriptor descriptor = new ItemDescriptorBuilder(item).build();
 
-        String re = EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_ITEM.getOneBased() + " " + ItemUtil.getItemDescriptorDetails(descriptor);
-
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_ITEM.getOneBased() + " " + ItemUtil.getItemDescriptorDetails(descriptor));
-        
+
         assertEquals(new EditCommand(INDEX_FIRST_ITEM, descriptor), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -19,7 +19,6 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditCommand.EditItemDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -27,8 +26,9 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.NameContainsKeywordsPredicate;
-import seedu.address.testutil.EditItemDescriptorBuilder;
+import seedu.address.testutil.ItemDescriptorBuilder;
 import seedu.address.testutil.ItemBuilder;
 import seedu.address.testutil.ItemUtil;
 
@@ -59,9 +59,9 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_edit() throws Exception {
         Item item = new ItemBuilder().build();
-        EditItemDescriptor descriptor = new EditItemDescriptorBuilder(item).build();
+        ItemDescriptor descriptor = new ItemDescriptorBuilder(item).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_ITEM.getOneBased() + " " + ItemUtil.getEditItemDescriptorDetails(descriptor));
+                + INDEX_FIRST_ITEM.getOneBased() + " " + ItemUtil.getItemDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_ITEM, descriptor), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,9 +40,11 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_add() throws Exception {
-        Item item = new ItemBuilder().build();
-        AddCommand command = (AddCommand) parser.parseCommand(ItemUtil.getAddCommand(item));
-        assertEquals(new AddCommand(item), command);
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
+        AddCommand command = (AddCommand) parser.parseCommand(ItemUtil.getAddCommand(descriptor));
+
+        descriptor.setCount(1);  // Parser should set descriptor count to 1
+        assertEquals(new AddCommand(descriptor), command);
     }
 
     @Test
@@ -60,8 +64,13 @@ public class AddressBookParserTest {
     public void parseCommand_edit() throws Exception {
         Item item = new ItemBuilder().build();
         ItemDescriptor descriptor = new ItemDescriptorBuilder(item).build();
+
+        String re = EditCommand.COMMAND_WORD + " "
+                + INDEX_FIRST_ITEM.getOneBased() + " " + ItemUtil.getItemDescriptorDetails(descriptor);
+
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_ITEM.getOneBased() + " " + ItemUtil.getItemDescriptorDetails(descriptor));
+        
         assertEquals(new EditCommand(INDEX_FIRST_ITEM, descriptor), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -26,10 +26,10 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditCommand.EditItemDescriptor;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.Name;
 import seedu.address.model.tag.Tag;
-import seedu.address.testutil.EditItemDescriptorBuilder;
+import seedu.address.testutil.ItemDescriptorBuilder;
 
 public class EditCommandParserTest {
 
@@ -95,7 +95,7 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + NAME_DESC_BAGEL + ID_DESC_BAGEL
                 + TAG_DESC_BAKED + TAG_DESC_POPULAR;
 
-        EditItemDescriptor descriptor = new EditItemDescriptorBuilder().withName(VALID_NAME_BAGEL)
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL)
                 .withId(VALID_ID_BAGEL).withTags(VALID_TAG_BAKED, VALID_TAG_POPULAR).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
@@ -107,7 +107,7 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_FIRST_ITEM;
         String userInput = targetIndex.getOneBased() + ID_DESC_BAGEL + TAG_DESC_POPULAR;
 
-        EditItemDescriptor descriptor = new EditItemDescriptorBuilder()
+        ItemDescriptor descriptor = new ItemDescriptorBuilder()
                 .withId(VALID_ID_BAGEL).withTags(VALID_TAG_POPULAR).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
@@ -119,19 +119,19 @@ public class EditCommandParserTest {
         // name
         Index targetIndex = INDEX_THIRD_ITEM;
         String userInput = targetIndex.getOneBased() + NAME_DESC_BAGEL;
-        EditItemDescriptor descriptor = new EditItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // id
         userInput = targetIndex.getOneBased() + ID_DESC_BAGEL;
-        descriptor = new EditItemDescriptorBuilder().withId(VALID_ID_BAGEL).build();
+        descriptor = new ItemDescriptorBuilder().withId(VALID_ID_BAGEL).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
         userInput = targetIndex.getOneBased() + TAG_DESC_POPULAR;
-        descriptor = new EditItemDescriptorBuilder().withTags(VALID_TAG_POPULAR).build();
+        descriptor = new ItemDescriptorBuilder().withTags(VALID_TAG_POPULAR).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -142,7 +142,7 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + NAME_DESC_BAGEL + ID_DESC_BAGEL + ID_DESC_DONUT
                 + TAG_DESC_BAKED + NAME_DESC_DONUT + TAG_DESC_POPULAR;
 
-        EditItemDescriptor descriptor = new EditItemDescriptorBuilder().withName(VALID_NAME_DONUT)
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_DONUT)
                 .withId(VALID_ID_DONUT).withTags(VALID_TAG_BAKED, VALID_TAG_POPULAR)
                 .build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
@@ -155,14 +155,14 @@ public class EditCommandParserTest {
         // no other valid values specified
         Index targetIndex = INDEX_FIRST_ITEM;
         String userInput = targetIndex.getOneBased() + INVALID_NAME_DESC + NAME_DESC_BAGEL;
-        EditItemDescriptor descriptor = new EditItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // other valid values specified
         userInput = targetIndex.getOneBased() + ID_DESC_DONUT + INVALID_NAME_DESC + NAME_DESC_DONUT
                 + TAG_DESC_POPULAR;
-        descriptor = new EditItemDescriptorBuilder().withName(VALID_NAME_DONUT).withId(VALID_ID_DONUT)
+        descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_DONUT).withId(VALID_ID_DONUT)
                 .withTags(VALID_TAG_POPULAR).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -173,7 +173,7 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_ITEM;
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
-        EditItemDescriptor descriptor = new EditItemDescriptorBuilder().withTags().build();
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withTags().build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/address/model/InventoryTest.java
+++ b/src/test/java/seedu/address/model/InventoryTest.java
@@ -3,9 +3,14 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_POPULAR;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalItems.APPLE_PIE;
+import static seedu.address.testutil.TypicalItems.BAGEL;
+import static seedu.address.testutil.TypicalItems.DONUT;
 import static seedu.address.testutil.TypicalItems.getTypicalInventory;
 
 import java.util.Arrays;
@@ -18,9 +23,12 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.Name;
 import seedu.address.model.item.exceptions.DuplicateItemException;
+import seedu.address.model.item.exceptions.ItemNotFoundException;
 import seedu.address.testutil.ItemBuilder;
+import seedu.address.testutil.ItemDescriptorBuilder;
 
 public class InventoryTest {
 
@@ -84,6 +92,75 @@ public class InventoryTest {
 
         // Search by id
         assertTrue(inventory.hasItem(APPLE_PIE.getId()));
+    }
+
+    @Test
+    public void getItem_itemInInventory_returnsItem() {
+        inventory.addItem(BAGEL);
+
+        // Search by name
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
+        assertEquals(inventory.getItems(descriptor), List.of(BAGEL));
+
+        // Search by id
+        descriptor = new ItemDescriptorBuilder().withId(VALID_ID_BAGEL).build();
+        assertEquals(inventory.getItems(descriptor), List.of(BAGEL));
+
+        // Search by name and id
+        descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
+        assertEquals(inventory.getItems(descriptor), List.of(BAGEL));
+    }
+
+    @Test
+    public void getItem_itemNotInInventory_returnEmptyList() {
+        inventory.addItem(DONUT);
+
+        // Search by name
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
+        assertEquals(inventory.getItems(descriptor), List.of());
+
+        // Search by id
+        descriptor = new ItemDescriptorBuilder().withId(VALID_ID_BAGEL).build();
+        assertEquals(inventory.getItems(descriptor), List.of());
+
+        // Search by name and id
+        descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
+        assertEquals(inventory.getItems(descriptor), List.of());
+    }
+
+    @Test
+    public void getItem_multipleMatches_returnMultiple() {
+        inventory.addItem(DONUT);
+        inventory.addItem(BAGEL);
+
+        ItemDescriptor descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_DONUT).build();
+        assertEquals(inventory.getItems(descriptor), List.of(DONUT, BAGEL));
+    }
+
+    @Test
+    public void restockItem_success() {
+        inventory.addItem(BAGEL.updateCount(5));
+        inventory.restockItem(BAGEL, 5);
+
+        Inventory expectedInventory = new Inventory();
+        expectedInventory.addItem(BAGEL.updateCount(10));
+
+        assertEquals(inventory, expectedInventory);
+    }
+
+    @Test
+    public void restockItem_itemNotInInventory_throwsException() {
+        inventory.addItem(BAGEL);
+
+        assertThrows(ItemNotFoundException.class, () -> inventory.restockItem(DONUT, 5));
+    }
+
+    @Test
+    public void restockItem_nullItem_throwException() {
+        assertThrows(NullPointerException.class, () -> inventory.restockItem(null, 0));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -3,23 +3,34 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_DONUT;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalItems.APPLE_PIE;
+import static seedu.address.testutil.TypicalItems.BAGEL;
 import static seedu.address.testutil.TypicalItems.BANANA_MUFFIN;
+import static seedu.address.testutil.TypicalItems.DONUT;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.Name;
 import seedu.address.model.item.NameContainsKeywordsPredicate;
 import seedu.address.testutil.InventoryBuilder;
+import seedu.address.testutil.ItemDescriptorBuilder;
 
 public class ModelManagerTest {
 
@@ -104,6 +115,52 @@ public class ModelManagerTest {
         assertTrue(modelManager.hasItem(APPLE_PIE.getName()));
         // Search by id
         assertTrue(modelManager.hasItem(APPLE_PIE.getId()));
+    }
+
+    @Test
+    public void getItem_itemInInventory_returnsItem() {
+        modelManager.addItem(BAGEL);
+
+        // Search by name
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
+        assertEquals(modelManager.getItems(descriptor), List.of(BAGEL));
+
+        // Search by id
+        descriptor = new ItemDescriptorBuilder().withId(VALID_ID_BAGEL).build();
+        assertEquals(modelManager.getItems(descriptor), List.of(BAGEL));
+
+        // Search by name and id
+        descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
+        assertEquals(modelManager.getItems(descriptor), List.of(BAGEL));
+    }
+
+    @Test
+    public void getItem_itemNotInInventory_returnEmptyList() {
+        modelManager.addItem(DONUT);
+
+        // Search by name
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
+        assertEquals(modelManager.getItems(descriptor), List.of());
+
+        // Search by id
+        descriptor = new ItemDescriptorBuilder().withId(VALID_ID_BAGEL).build();
+        assertEquals(modelManager.getItems(descriptor), List.of());
+
+        // Search by name and id
+        descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
+        assertEquals(modelManager.getItems(descriptor), List.of());
+    }
+
+    @Test
+    public void getItem_multipleMatches_returnMultiple() {
+        modelManager.addItem(DONUT);
+        modelManager.addItem(BAGEL);
+
+        ItemDescriptor descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_DONUT).build();
+        assertEquals(modelManager.getItems(descriptor), List.of(DONUT, BAGEL));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_DONUT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_DONUT;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalItems.APPLE_PIE;
@@ -16,11 +15,9 @@ import static seedu.address.testutil.TypicalItems.DONUT;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -2,11 +2,13 @@ package seedu.address.model;
 
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.Name;
 
 /**
@@ -70,6 +72,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public List<Item> getItems(ItemDescriptor descriptor) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public boolean hasItem(String id) {
         throw new AssertionError("This method should not be called.");
     }
@@ -86,6 +93,11 @@ public class ModelStub implements Model {
 
     @Override
     public void setItem(Item target, Item editedItem) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void restockItem(Item target, int amount) {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -72,12 +72,12 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public List<Item> getItems(ItemDescriptor descriptor) {
+    public boolean hasItem(String id) {
         throw new AssertionError("This method should not be called.");
     }
 
     @Override
-    public boolean hasItem(String id) {
+    public List<Item> getItems(ItemDescriptor descriptor) {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/model/item/ItemDescriptorTest.java
+++ b/src/test/java/seedu/address/model/item/ItemDescriptorTest.java
@@ -11,13 +11,13 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_POPULAR;
 import static seedu.address.testutil.TypicalItems.APPLE_PIE;
 import static seedu.address.testutil.TypicalItems.BANANA_MUFFIN;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.ItemDescriptorBuilder;
-
-import java.util.HashSet;
-import java.util.Set;
 
 public class ItemDescriptorTest {
 

--- a/src/test/java/seedu/address/model/item/ItemDescriptorTest.java
+++ b/src/test/java/seedu/address/model/item/ItemDescriptorTest.java
@@ -1,0 +1,112 @@
+package seedu.address.model.item;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNT_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BAKED;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_POPULAR;
+import static seedu.address.testutil.TypicalItems.APPLE_PIE;
+import static seedu.address.testutil.TypicalItems.BANANA_MUFFIN;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.ItemDescriptorBuilder;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ItemDescriptorTest {
+
+    @Test
+    public void setAndGetFields_success() {
+
+        // Set Name
+        ItemDescriptor descriptor = new ItemDescriptor();
+        descriptor.setName(new Name(VALID_NAME_BAGEL));
+        assertEquals(descriptor.getName().get(), new Name(VALID_NAME_BAGEL));
+
+        // Set Id
+        descriptor = new ItemDescriptor();
+        descriptor.setId(VALID_ID_BAGEL);
+        assertEquals(descriptor.getId().get(), VALID_ID_BAGEL);
+
+        // Set Count
+        descriptor = new ItemDescriptor();
+        descriptor.setCount(Integer.parseInt(VALID_COUNT_BAGEL));
+        assertEquals(descriptor.getCount().get(), Integer.parseInt(VALID_COUNT_BAGEL));
+
+        // Set Tags
+        descriptor = new ItemDescriptor();
+        Set<Tag> tagSet = new HashSet<>();
+        tagSet.add(new Tag(VALID_TAG_BAKED));
+        tagSet.add(new Tag(VALID_TAG_POPULAR));
+
+        descriptor.setTags(tagSet);
+        assertEquals(descriptor.getTags().get(), tagSet);
+    }
+
+    @Test
+    public void getFields_emptyFields_emptyOptionals() {
+        ItemDescriptor descriptor = new ItemDescriptor();
+
+        // Get Name
+        assertTrue(descriptor.getName().isEmpty());
+
+        // Get Id
+        assertTrue(descriptor.getId().isEmpty());
+
+        // Get Count
+        assertTrue(descriptor.getCount().isEmpty());
+
+        // Set Tags
+        assertTrue(descriptor.getTags().isEmpty());
+    }
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        ItemDescriptor pieDescriptor = new ItemDescriptorBuilder(APPLE_PIE).build();
+        ItemDescriptor pieDescriptorCopy = new ItemDescriptorBuilder(pieDescriptor).build();
+        assertTrue(pieDescriptor.equals(pieDescriptorCopy));
+
+        // same object -> returns true
+        assertTrue(pieDescriptor.equals(pieDescriptor));
+
+        // null -> returns false
+        assertFalse(pieDescriptor.equals(null));
+
+        // different type -> returns false
+        assertFalse(pieDescriptor.equals(5));
+
+        // different item -> returns false
+        ItemDescriptor muffinDescriptor = new ItemDescriptorBuilder(BANANA_MUFFIN).build();
+        assertFalse(pieDescriptor.equals(muffinDescriptor));
+
+        // different name -> returns false
+        ItemDescriptor editedPie = new ItemDescriptorBuilder(pieDescriptor)
+                .withName(VALID_NAME_BAGEL).build();
+        assertFalse(pieDescriptor.equals(editedPie));
+
+        // different id -> returns false
+        editedPie = new ItemDescriptorBuilder(pieDescriptor)
+                .withId(VALID_ID_BAGEL).build();
+        assertFalse(pieDescriptor.equals(editedPie));
+
+        // different count -> returns false
+        int newCount = APPLE_PIE.getCount() + 1;
+        editedPie = new ItemDescriptorBuilder(pieDescriptor)
+                .withCount(newCount).build();
+        assertFalse(pieDescriptor.equals(editedPie));
+
+        // different tags -> returns false
+        editedPie = new ItemDescriptorBuilder(pieDescriptor)
+                .withTags(VALID_TAG_POPULAR).build();
+        assertFalse(pieDescriptor.equals(editedPie));
+    }
+}

--- a/src/test/java/seedu/address/model/item/ItemDescriptorTest.java
+++ b/src/test/java/seedu/address/model/item/ItemDescriptorTest.java
@@ -2,11 +2,9 @@ package seedu.address.model.item;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNT_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_DONUT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BAKED;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_POPULAR;

--- a/src/test/java/seedu/address/model/item/UniqueItemListTest.java
+++ b/src/test/java/seedu/address/model/item/UniqueItemListTest.java
@@ -3,11 +3,16 @@ package seedu.address.model.item;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_POPULAR;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalItems.APPLE_PIE;
+import static seedu.address.testutil.TypicalItems.BAGEL;
 import static seedu.address.testutil.TypicalItems.BANANA_MUFFIN;
 import static seedu.address.testutil.TypicalItems.CHOCOCHIP;
+import static seedu.address.testutil.TypicalItems.DONUT;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -18,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.item.exceptions.DuplicateItemException;
 import seedu.address.model.item.exceptions.ItemNotFoundException;
 import seedu.address.testutil.ItemBuilder;
+import seedu.address.testutil.ItemDescriptorBuilder;
 
 public class UniqueItemListTest {
 
@@ -120,6 +126,53 @@ public class UniqueItemListTest {
         uniqueItemList.add(BANANA_MUFFIN);
         assertThrows(DuplicateItemException.class, () -> uniqueItemList.setItem(APPLE_PIE, BANANA_MUFFIN));
     }
+
+    @Test
+    public void getItem_itemInInventory_returnsItem() {
+        uniqueItemList.add(BAGEL);
+
+        // Search by name
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
+        assertEquals(uniqueItemList.get(descriptor), List.of(BAGEL));
+
+        // Search by id
+        descriptor = new ItemDescriptorBuilder().withId(VALID_ID_BAGEL).build();
+        assertEquals(uniqueItemList.get(descriptor), List.of(BAGEL));
+
+        // Search by name and id
+        descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
+        assertEquals(uniqueItemList.get(descriptor), List.of(BAGEL));
+    }
+
+    @Test
+    public void getItem_itemNotInInventory_returnEmptyList() {
+        uniqueItemList.add(DONUT);
+
+        // Search by name
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
+        assertEquals(uniqueItemList.get(descriptor), List.of());
+
+        // Search by id
+        descriptor = new ItemDescriptorBuilder().withId(VALID_ID_BAGEL).build();
+        assertEquals(uniqueItemList.get(descriptor), List.of());
+
+        // Search by name and id
+        descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
+        assertEquals(uniqueItemList.get(descriptor), List.of());
+    }
+
+    @Test
+    public void getItem_multipleMatches_returnMultiple() {
+        uniqueItemList.add(DONUT);
+        uniqueItemList.add(BAGEL);
+
+        ItemDescriptor descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_DONUT).build();
+        assertEquals(uniqueItemList.get(descriptor), List.of(DONUT, BAGEL));
+    }
+
 
     @Test
     public void remove_nullItem_throwsNullPointerException() {

--- a/src/test/java/seedu/address/testutil/ItemDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/ItemDescriptorBuilder.java
@@ -4,31 +4,31 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import seedu.address.logic.commands.EditCommand.EditItemDescriptor;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.Name;
 import seedu.address.model.tag.Tag;
 
 /**
  * A utility class to help with building EditItemDescriptor objects.
  */
-public class EditItemDescriptorBuilder {
+public class ItemDescriptorBuilder {
 
-    private EditItemDescriptor descriptor;
+    private ItemDescriptor descriptor;
 
-    public EditItemDescriptorBuilder() {
-        descriptor = new EditItemDescriptor();
+    public ItemDescriptorBuilder() {
+        descriptor = new ItemDescriptor();
     }
 
-    public EditItemDescriptorBuilder(EditItemDescriptor descriptor) {
-        this.descriptor = new EditItemDescriptor(descriptor);
+    public ItemDescriptorBuilder(ItemDescriptor descriptor) {
+        this.descriptor = new ItemDescriptor(descriptor);
     }
 
     /**
      * Returns an {@code EditItemDescriptor} with fields containing {@code item}'s details
      */
-    public EditItemDescriptorBuilder(Item item) {
-        descriptor = new EditItemDescriptor();
+    public ItemDescriptorBuilder(Item item) {
+        descriptor = new ItemDescriptor();
         descriptor.setName(item.getName());
         descriptor.setId(item.getId());
         descriptor.setTags(item.getTags());

--- a/src/test/java/seedu/address/testutil/ItemDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/ItemDescriptorBuilder.java
@@ -31,6 +31,7 @@ public class ItemDescriptorBuilder {
         descriptor = new ItemDescriptor();
         descriptor.setName(item.getName());
         descriptor.setId(item.getId());
+        descriptor.setCount(item.getCount());
         descriptor.setTags(item.getTags());
     }
 

--- a/src/test/java/seedu/address/testutil/ItemDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/ItemDescriptorBuilder.java
@@ -35,41 +35,49 @@ public class ItemDescriptorBuilder {
     }
 
     /**
-     * Sets the {@code Name} of the {@code EditItemDescriptor} that we are building.
+     * Sets the {@code Name} of the {@code ItemDescriptor} that we are building.
      */
-    public EditItemDescriptorBuilder withName(String name) {
+    public ItemDescriptorBuilder withName(String name) {
         descriptor.setName(new Name(name));
         return this;
     }
 
     /**
-     * Sets the {@code Name} of the {@code EditItemDescriptor} that we are building.
+     * Sets the {@code Count} of the {@code ItemDescriptor} that we are building.
      */
-    public EditItemDescriptorBuilder withCount(String count) {
+    public ItemDescriptorBuilder withCount(String count) {
         descriptor.setCount(Integer.parseInt(count));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Count} of the {@code ItemDescriptor} that we are building.
+     */
+    public ItemDescriptorBuilder withCount(int count) {
+        descriptor.setCount(count);
         return this;
     }
 
 
     /**
-     * Sets the id of the {@code EditItemDescriptor} that we are building.
+     * Sets the {@code id} of the {@code ItemDescriptor} that we are building.
      */
-    public EditItemDescriptorBuilder withId(String id) {
+    public ItemDescriptorBuilder withId(String id) {
         descriptor.setId(id);
         return this;
     }
 
     /**
-     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code EditItemDescriptor}
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code ItemDescriptor}
      * that we are building.
      */
-    public EditItemDescriptorBuilder withTags(String... tags) {
+    public ItemDescriptorBuilder withTags(String... tags) {
         Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
         descriptor.setTags(tagSet);
         return this;
     }
 
-    public EditItemDescriptor build() {
+    public ItemDescriptor build() {
         return descriptor;
     }
 }

--- a/src/test/java/seedu/address/testutil/ItemUtil.java
+++ b/src/test/java/seedu/address/testutil/ItemUtil.java
@@ -21,8 +21,10 @@ public class ItemUtil {
     /**
      * Returns an add command string for adding the {@code item}.
      */
-    public static String getAddCommand(Item item) {
-        return AddCommand.COMMAND_WORD + " " + getItemDetails(item);
+    public static String getAddCommand(ItemDescriptor itemDescriptor) {
+        String arguments = getItemDescriptorDetails(itemDescriptor);
+
+        return AddCommand.COMMAND_WORD + " " + arguments.substring(PREFIX_NAME.toString().length());
     }
 
     /**
@@ -55,6 +57,7 @@ public class ItemUtil {
         StringBuilder sb = new StringBuilder();
         descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
         descriptor.getId().ifPresent(id -> sb.append(PREFIX_ID).append(id).append(" "));
+        descriptor.getCount().ifPresent(count -> sb.append(PREFIX_COUNT).append(count).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {

--- a/src/test/java/seedu/address/testutil/ItemUtil.java
+++ b/src/test/java/seedu/address/testutil/ItemUtil.java
@@ -9,8 +9,8 @@ import java.util.Set;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand.EditItemDescriptor;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -49,9 +49,9 @@ public class ItemUtil {
     }
 
     /**
-     * Returns the part of command string for the given {@code EditItemDescriptor}'s details.
+     * Returns the part of command string for the given {@code ItemDescriptor}'s details.
      */
-    public static String getEditItemDescriptorDetails(EditItemDescriptor descriptor) {
+    public static String getItemDescriptorDetails(ItemDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
         descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
         descriptor.getId().ifPresent(id -> sb.append(PREFIX_ID).append(id).append(" "));

--- a/src/test/java/seedu/address/testutil/TypicalItems.java
+++ b/src/test/java/seedu/address/testutil/TypicalItems.java
@@ -81,7 +81,7 @@ public class TypicalItems {
     }
 
     public static List<Item> getTypicalItems() {
-        return new ArrayList<>(Arrays.asList(APPLE_PIE.updateCount(5), BANANA_MUFFIN, CHOCOCHIP,
+        return new ArrayList<>(Arrays.asList(APPLE_PIE, BANANA_MUFFIN, CHOCOCHIP,
                 DALGONA_COFFEE, EGGNOG, FOREST_CAKE, GRANOLA_BAR));
     }
 }


### PR DESCRIPTION
Fixes #45 and fixes #48.

Many of our command logic requires us to search by either name or id. With no clear way to do this, logic becomes cumbersome.

Let's create a `ItemDescriptor` class that aims to describe an item, much like the existing `EditItemDescriptor` that `EditCommand` uses. The class instance can hold partial details of an `Item`. By calling `Model::getItems(ItemDescriptor)` we can retrieve the list of items that match the given description.

An example of how `ItemDescriptor` is effectively used can be found in `AddCommand::execute`. Similar logic can be applied to the other commands subsequently (e.g. `DeleteCommand`, `AddToOrderCommand`)

In this commit, I've taken the opportunity to adjust add command's format and restore `Item`'s immutability as well.