### PR TITLE
Add remove command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,7 +9,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_ITEM_DISPLAYED_INDEX = "The item index provided is invalid";
     public static final String MESSAGE_ITEMS_LISTED_OVERVIEW = "%1$d items listed!";
-    public static final String MESSAGE_INVALID_COUNT_INTEGER = "The count provided cannot be negative!";
+    public static final String MESSAGE_INVALID_COUNT_INTEGER = "The count provided must be positive!";
     public static final String MESSAGE_INVALID_COUNT_FORMAT = "The count provided must be integer!";
     public static final String MESSAGE_INVALID_ID_FORMAT = "The id provided must be integer!";
     public static final String MESSAGE_INVALID_ID_LENGTH_AND_SIGN = "The id provided must be positive and of 6 digits!";

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -33,7 +33,7 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "popular";
 
     public static final String MESSAGE_SUCCESS_NEW = "New item added: %1$s";
-    public static final String MESSAGE_SUCCESS_REPLENISH = "Item replenished: %dx %s";
+    public static final String MESSAGE_SUCCESS_REPLENISH = "Item replenished: %d x %s";
     public static final String MESSAGE_INCOMPLETE_INFO = "Item has not been added before,"
             + " please provide both a name and id";
     public static final String MESSAGE_MULTIPLE_MATCHES = "Multiple candidates found, which one did you mean to add?";
@@ -75,7 +75,7 @@ public class AddCommand extends Command {
 
         Item target = matchingItems.get(0);
         int amount = toAddDescriptor.getCount().get();
-        model.restockItem(target, toAddDescriptor.getCount().get());
+        model.restockItem(target, amount);
         return new CommandResult(String.format(MESSAGE_SUCCESS_REPLENISH, amount, target.getName()));
     }
 

--- a/src/main/java/seedu/address/logic/commands/RemoveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveCommand.java
@@ -1,0 +1,81 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+
+import java.util.List;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
+
+/**
+ * Deletes an item identified using it's displayed index from the inventory.
+ */
+public class RemoveCommand extends Command {
+
+    public static final String COMMAND_WORD = "remove";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Removes the given item(s) from the inventory.\n"
+            + "Parameters: NAME "
+            + "Or " + PREFIX_ID + "ID"
+            + "[" + PREFIX_COUNT + "COUNT" + "]\n"
+            + "Example: " + COMMAND_WORD + "Apple Pie"
+            + PREFIX_COUNT + " 1";
+
+    public static final String MESSAGE_SUCCESS = "Item removed: %d x %s";
+    public static final String MESSAGE_ITEM_NOT_FOUND = "No such item in the inventory";
+    public static final String MESSAGE_INSUFFICIENT_ITEM = "Only %d of %s in the inventory!";
+    public static final String MESSAGE_MULTIPLE_MATCHES =
+            "Multiple candidates found, which one did you mean to remove?";
+
+    private final ItemDescriptor toRemoveDescriptor;
+
+    /**
+     * Creates a RemoveCommand to remove the Item specified by the {@code ItemDescriptor}
+     */
+    public RemoveCommand(ItemDescriptor itemDescriptor) {
+        requireNonNull(itemDescriptor);
+        toRemoveDescriptor = itemDescriptor;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        List<Item> matchingItems = model.getItems(toRemoveDescriptor);
+
+        // Check if item exists in inventory
+        if (matchingItems.size() == 0) {
+            throw new CommandException(MESSAGE_ITEM_NOT_FOUND);
+        }
+
+        // Check that only 1 item fit the description
+        if (matchingItems.size() > 1) {
+            model.updateFilteredItemList(toRemoveDescriptor::isMatch);
+            throw new CommandException(MESSAGE_MULTIPLE_MATCHES);
+        }
+
+        Item target = matchingItems.get(0);
+        int amount = toRemoveDescriptor.getCount().get();
+        // Check that enough of item to remove
+        if (target.getCount() < amount) {
+            throw new CommandException(
+                    String.format(MESSAGE_INSUFFICIENT_ITEM, target.getCount(), target.getName())
+            );
+        }
+
+        model.removeItem(target, amount);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, amount, target.getName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RemoveCommand // instanceof handles nulls
+                && toRemoveDescriptor.equals(((RemoveCommand) other).toRemoveDescriptor));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RemoveCommand;
 import seedu.address.logic.commands.RemoveFromOrderCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.StartOrderCommand;
@@ -57,6 +58,9 @@ public class AddressBookParser {
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);
+
+        case RemoveCommand.COMMAND_WORD:
+            return new RemoveCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -6,7 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.item.Name;
+import seedu.address.model.item.ItemDescriptor;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -23,25 +23,23 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_COUNT);
 
-        // Check that either name (preamble) or id is specified, not both
-        if (!(argMultimap.getPreamble().isEmpty() ^ argMultimap.getValue(PREFIX_ID).isEmpty())) {
+        // Check that either name or id specified
+        if (argMultimap.getPreamble().isEmpty() && argMultimap.getValue(PREFIX_ID).isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
+        ItemDescriptor toDeleteDescriptor = new ItemDescriptor();
 
-        int count = -1;
-        if (argMultimap.getValue(PREFIX_COUNT).isPresent()) {
-            count = ParserUtil.parseCount(argMultimap.getValue(PREFIX_COUNT).get());
-        }
-
+        // Parse name
         if (!argMultimap.getPreamble().isEmpty()) {
-            // name specified
-            Name name = new Name(argMultimap.getPreamble());
-            return new DeleteCommand(name, count);
-        } else {
-            // id specified
-            String id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
-            return new DeleteCommand(id, count);
+            toDeleteDescriptor.setName(ParserUtil.parseName(argMultimap.getPreamble()));
         }
+
+        // Parse id
+        if (!argMultimap.getValue(PREFIX_ID).isEmpty()) {
+            toDeleteDescriptor.setId(ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get()));
+        }
+
+        return new DeleteCommand(toDeleteDescriptor);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
@@ -10,6 +10,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RemoveCommand;
 import seedu.address.logic.commands.RemoveFromOrderCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.StartOrderCommand;
@@ -37,6 +38,9 @@ public class HelpCommandParser implements Parser<HelpCommand> {
 
         case EditCommand.COMMAND_WORD:
             return new HelpCommand(EditCommand.MESSAGE_USAGE);
+
+        case RemoveCommand.COMMAND_WORD:
+            return new HelpCommand(RemoveCommand.MESSAGE_USAGE);
 
         case DeleteCommand.COMMAND_WORD:
             return new HelpCommand(DeleteCommand.MESSAGE_USAGE);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -85,7 +85,7 @@ public class ParserUtil {
             throw new ParseException(Messages.MESSAGE_INVALID_COUNT_FORMAT);
         }
 
-        if (Integer.parseInt(count) >= 0) {
+        if (Integer.parseInt(count) > 0) {
             return Integer.parseInt(count);
         } else {
             throw new ParseException(Messages.MESSAGE_INVALID_COUNT_INTEGER);

--- a/src/main/java/seedu/address/logic/parser/RemoveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveCommandParser.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.logic.commands.RemoveCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.item.ItemDescriptor;
+
+/**
+ * Parses input arguments and creates a new AddCommand object
+ */
+public class RemoveCommandParser implements Parser<RemoveCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the RemoveCommand
+     * and returns an RemoveCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public RemoveCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_COUNT, PREFIX_TAG);
+
+        if (argMultimap.getValue(PREFIX_ID).isEmpty() && argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveCommand.MESSAGE_USAGE));
+        }
+
+        ItemDescriptor toAddDescriptor = new ItemDescriptor();
+
+        // Parse name
+        if (!argMultimap.getPreamble().isEmpty()) {
+            toAddDescriptor.setName(ParserUtil.parseName(argMultimap.getPreamble()));
+        }
+        // Parse Id
+        if (argMultimap.getValue(PREFIX_ID).isPresent()) {
+            toAddDescriptor.setId(ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get()));
+        }
+        // Parse count
+        if (argMultimap.getValue(PREFIX_COUNT).isPresent()) {
+            toAddDescriptor.setCount(ParserUtil.parseCount(argMultimap.getValue(PREFIX_COUNT).get()));
+        } else {
+            toAddDescriptor.setCount(1);
+        }
+
+        return new RemoveCommand(toAddDescriptor);
+    }
+
+}

--- a/src/main/java/seedu/address/model/Inventory.java
+++ b/src/main/java/seedu/address/model/Inventory.java
@@ -8,7 +8,6 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
-import seedu.address.model.item.Name;
 import seedu.address.model.item.UniqueItemList;
 
 /**
@@ -72,22 +71,6 @@ public class Inventory implements ReadOnlyInventory {
     }
 
     /**
-     * Returns true if an item with the given {@code name} exists in the inventory.
-     */
-    public boolean hasItem(Name name) {
-        requireNonNull(name);
-        return items.contains(name);
-    }
-
-    /**
-     * Returns true if an item with the given {@code id} exists in the inventory.
-     */
-    public boolean hasItem(String id) {
-        requireNonNull(id);
-        return items.contains(id);
-    }
-
-    /**
      * Returns list of items in the inventory that matches the given {@code ItemDescriptor}
      * @see ItemDescriptor#isMatch(Item)
      */
@@ -96,33 +79,6 @@ public class Inventory implements ReadOnlyInventory {
         return items.get(descriptor);
     }
 
-    /**
-     * Returns the item with the same name as {@code item} that exists in the inventory.
-     */
-    public Item getItemWithName(String name) {
-        requireNonNull(name);
-        ObservableList<Item> ls = items.asUnmodifiableObservableList();
-        for (Item item : ls) {
-            if (item.getName().toString().equals(name)) {
-                return item;
-            }
-        }
-        throw new AssertionError("unreachable code (if implemented correctly)");
-    }
-
-    /**
-     * Returns the item with the same id as {@code item} that exists in the inventory.
-     */
-    public Item getItemWithId(String id) {
-        requireNonNull(id);
-        ObservableList<Item> ls = items.asUnmodifiableObservableList();
-        for (Item item : ls) {
-            if (item.getId().toString().equals(id)) {
-                return item;
-            }
-        }
-        throw new AssertionError("unreachable code (if implemented correctly)");
-    }
 
     /**
      * Adds an item to the inventory.
@@ -205,7 +161,7 @@ public class Inventory implements ReadOnlyInventory {
     }
 
     /**
-     * Increments the count of the given item {@code target} by {@code amount}.
+     * Increments the count of the given {@code target} in the inventory by {@code amount}.
      * {@code target} must exist in the inventory.
      */
     public void restockItem(Item target, int amount) {
@@ -216,61 +172,28 @@ public class Inventory implements ReadOnlyInventory {
     }
 
     /**
-     * Removes the specified amount of item with the given {@code name} from this {@code Inventory}.
-     * If amount of item drops to 0 or less, remove the entire item from inventory
-     * The specified item must exist in the inventory.
-     * @param name name of item to remove
-     * @param amount number of the item to remove, set to -1 to remove all.
-     * @returns the deleted item
+     * Decrements the count of the given {@code target} in the inventory by {@code amount}.
+     * {@code target} must exist in the inventory.
+     * @throws IllegalArgumentException if {@code target}'s count less than amount.
      */
-    public Item removeItem(Name name, Integer amount) {
-        requireNonNull(name);
+    public void removeItem(Item target, int amount) {
+        requireNonNull(target);
 
-        Item existingItem = items.getItem(name).get();
-        items.remove(existingItem);
-
-        int amountDeleted = (amount == -1)
-                ? existingItem.getCount() : Math.min(amount, existingItem.getCount());
-
-        int newCount = existingItem.getCount() - amountDeleted;
-        if (newCount > 0) {
-            items.add(existingItem.updateCount(newCount));
+        if (target.getCount() < amount) {
+            throw new IllegalArgumentException();
         }
 
-        return existingItem.updateCount(amountDeleted);
+        Item newItem = target.updateCount(target.getCount() - amount);
+        items.setItem(target, newItem);
     }
 
     /**
-     * Removes the specified amount of item with the given {@code id} from this {@code Inventory}.
-     * If amount of item drops to 0 or less, remove the entire item from inventory
-     * The specified item must exist in the inventory.
-     * @param id id of item to remove
-     * @param amount amount of the item to remove, set to -1 to remove all.
-     * @returns the deleted item
+     * Deletes the specified item entirely from inventory.
      */
-    public Item removeItem(String id, Integer amount) {
-        requireNonNull(id);
-
-        Item existingItem = items.getItem(id).get();
-        items.remove(existingItem);
-
-        int amountDeleted = (amount == -1)
-                ? existingItem.getCount() : Math.min(amount, existingItem.getCount());
-
-        int newCount = existingItem.getCount() - amountDeleted;
-        if (newCount > 0) {
-            items.add(existingItem.updateCount(newCount));
-        }
-
-        return existingItem.updateCount(amountDeleted);
-    }
-
-    /**
-     * Removes the specified item entirely from inventory.
-     */
-    public Item removeItem(Item toRemove) {
+    public void deleteItem(Item toRemove) {
         requireNonNull(toRemove);
-        return removeItem(toRemove.getName(), toRemove.getCount());
+
+        items.remove(toRemove);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -9,7 +9,6 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
-import seedu.address.model.item.Name;
 
 /**
  * The API of the Model component.
@@ -63,38 +62,15 @@ public interface Model {
     boolean hasItem(Item item);
 
     /**
-     * Returns true if an item with the given {@code name} exists in the inventory.
-     */
-    boolean hasItem(Name name);
-
-    /**
-     * Returns true if an item with the given {@code id} exists in the inventory.
-     * @see ItemDescriptor#isMatch(Item)
-     */
-    boolean hasItem(String id);
-
-    /**
      * Returns list of items in the inventory that matches the given {@code ItemDescriptor}
      */
     List<Item> getItems(ItemDescriptor descriptor);
 
     /**
-     * Deletes item in the inventory with the given name.
+     * Deletes {@code item} from the inventory .
      * The item must exist in the inventory.
-     * @param name name of the item to remove
-     * @param count count of the item to remove, set to -1 to remove all
-     * @returns the deleted item
      */
-    Item deleteItem(Name name, int count);
-
-    /**
-     * Deletes item in the inventory with the given id.
-     * The item must exist in the inventory.
-     * @param id id of the item to remove
-     * @param count count of the item to remove, set to -1 to remove all
-     * @returns the deleted item
-     */
-    Item deleteItem(String id, int count);
+    void deleteItem(Item item);
 
     /**
      * Adds the given item into inventory
@@ -109,10 +85,17 @@ public interface Model {
     void setItem(Item target, Item editedItem);
 
     /**
-     * Increments the count of the given item {@code target} with {@code amount}.
+     * Increments the count of the given {@code target} in the inventory by {@code amount}.
      * {@code target} must exist in the inventory.
      */
     void restockItem(Item target, int amount);
+
+    /**
+     * Decrements the count of the given {@code target} in the inventory by {@code amount}.
+     * {@code target} must exist in the inventory.
+     * {@code amount} must be less than {@code target}'s count.
+     */
+    void removeItem(Item target, int amount);
 
     /**
      * Sorts the item list using the given {@code comparator}.
@@ -154,20 +137,4 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredItemList(Predicate<Item> predicate);
-
-    /**
-     * Gets Item with the same name.
-     *
-     * @param name The name of the item that wants to be searched
-     * @return the Item with the same name.
-     */
-    Item getItemWithName(String name);
-
-    /**
-     * Gets Item with the same id.
-     *
-     * @param id The name of the item that wants to be searched
-     * @return the Item with the same name.
-     */
-    Item getItemWithId(String id);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -16,7 +16,6 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
-import seedu.address.model.item.Name;
 
 /**
  * Represents the in-memory model of BogoBogo data.
@@ -102,31 +101,14 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean hasItem(Name name) {
-        requireNonNull(name);
-        return inventory.hasItem(name);
-    }
-
-    @Override
-    public boolean hasItem(String id) {
-        requireNonNull(id);
-        return inventory.hasItem(id);
-    }
-
-    @Override
     public List<Item> getItems(ItemDescriptor descriptor) {
         requireNonNull(descriptor);
         return inventory.getItems(descriptor);
     }
 
     @Override
-    public Item deleteItem(Name name, int count) {
-        return inventory.removeItem(name, count);
-    }
-
-    @Override
-    public Item deleteItem(String id, int count) {
-        return inventory.removeItem(id, count);
+    public void deleteItem(Item item) {
+        inventory.deleteItem(item);
     }
 
     @Override
@@ -146,6 +128,12 @@ public class ModelManager implements Model {
     public void restockItem(Item target, int amount) {
         requireNonNull(target);
         inventory.restockItem(target, amount);
+    }
+
+    @Override
+    public void removeItem(Item target, int amount) {
+        requireNonNull(target);
+        inventory.removeItem(target, amount);
     }
 
     @Override
@@ -188,18 +176,6 @@ public class ModelManager implements Model {
         return inventory.equals(other.inventory)
                 && userPrefs.equals(other.userPrefs)
                 && filteredItems.equals(other.filteredItems);
-    }
-
-    @Override
-    public Item getItemWithName(String name) {
-        requireNonNull(name);
-        return inventory.getItemWithName(name);
-    }
-
-    @Override
-    public Item getItemWithId(String id) {
-        requireNonNull(id);
-        return inventory.getItemWithId(id);
     }
 
     // ============== Order related methods ========================

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -76,7 +76,7 @@ public class Item {
      * @return
      */
     public Item updateCount(int newCount) {
-        assert(newCount > 0);
+        assert(newCount >= 0);
 
         return new Item(name, id, newCount, tags);
     }

--- a/src/main/java/seedu/address/model/item/UniqueItemList.java
+++ b/src/main/java/seedu/address/model/item/UniqueItemList.java
@@ -37,23 +37,7 @@ public class UniqueItemList implements Iterable<Item> {
      */
     public boolean contains(Item toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::isSameItem);
-    }
-
-    /**
-     * Returns true if the list contains an item with the given name
-     */
-    public boolean contains(Name name) {
-        requireNonNull(name);
-        return internalList.stream().anyMatch(item -> name.equals(item.getName()));
-    }
-
-    /**
-     * Returns true if the list contains an item with the given id
-     */
-    public boolean contains(String id) {
-        requireNonNull(id);
-        return internalList.stream().anyMatch(item -> id.equals(item.getId()));
+        return internalList.stream().anyMatch(x -> toCheck.isSameItem(x) && x.getCount() > 0);
     }
 
     /**
@@ -74,26 +58,6 @@ public class UniqueItemList implements Iterable<Item> {
     public Optional<Item> getItem(Item item) {
         requireNonNull(item);
         return internalList.stream().filter(item::equals).findFirst();
-    }
-
-    /**
-     * Returns an optional of the item in the list with the given {@code name}.
-     * If item does not exist, return an empty optional.
-     */
-    public Optional<Item> getItem(Name name) {
-        requireNonNull(name);
-        return internalList.stream()
-                .filter(item -> item.getName().equals(name)).findFirst();
-    }
-
-    /**
-     * Returns an optional of the item in the list with the given {@code id}.
-     * If item does not exist, return an empty optional.
-     */
-    public Optional<Item> getItem(String id) {
-        requireNonNull(id);
-        return internalList.stream()
-                .filter(item -> item.getId().equals(id)).findFirst();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RemoveCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
@@ -57,8 +57,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete apple pie";
-        assertCommandException(deleteCommand, String.format(DeleteCommand.MESSAGE_ITEM_NAME_NOT_FOUND, "apple pie"));
+        String removeCommand = "remove apple pie";
+        assertCommandException(removeCommand, String.format(RemoveCommand.MESSAGE_ITEM_NOT_FOUND, "apple pie"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -43,6 +43,7 @@ public class CommandTestUtil {
     public static final String ID_DESC_DONUT = " " + PREFIX_ID + VALID_ID_DONUT;
     public static final String COUNT_DESC_BAGEL = " " + PREFIX_COUNT + VALID_COUNT_BAGEL;
     public static final String COUNT_DESC_DONUT = " " + PREFIX_COUNT + VALID_COUNT_DONUT;
+    public static final String COUNT_DESC_ZERO = " " + PREFIX_COUNT + "0";
     public static final String TAG_DESC_BAKED = " " + PREFIX_TAG + VALID_TAG_BAKED;
     public static final String TAG_DESC_POPULAR = " " + PREFIX_TAG + VALID_TAG_POPULAR;
 
@@ -110,6 +111,20 @@ public class CommandTestUtil {
         assertEquals(expectedInventory, actualModel.getInventory());
         assertEquals(expectedFilteredList, actualModel.getFilteredItemList());
     }
+
+    /**
+     * Executes the given {@code command}, confirms that <br>
+     * - a {@code CommandException} is thrown <br>
+     * - the CommandException message matches {@code expectedMessage} <br>
+     * - the inventory, filtered item list and selected item in {@code actualModel} matches {@code expectedModel}
+     */
+    public static void assertCommandFailure(Command command, Model actualModel,
+                                            Model expectedModel, String expectedMessage) {
+        assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel));
+        assertEquals(actualModel.getInventory(), expectedModel.getInventory());
+        assertEquals(expectedModel.getFilteredItemList(), actualModel.getFilteredItemList());
+    }
+
     /**
      * Updates {@code model}'s filtered list to show only the item at the given {@code targetIndex} in the
      * {@code model}'s inventory.

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -3,12 +3,12 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_DONUT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_DONUT;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalItems.APPLE_PIE;
 import static seedu.address.testutil.TypicalItems.BAGEL;
+import static seedu.address.testutil.TypicalItems.DONUT;
 import static seedu.address.testutil.TypicalItems.getTypicalInventory;
 
 import org.junit.jupiter.api.Test;
@@ -21,9 +21,9 @@ import seedu.address.testutil.ItemDescriptorBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
- * {@code RemoveCommand}.
+ * {@code DeleteCommand}.
  */
-public class RemoveCommandTest {
+public class DeleteCommandTest {
 
     private Model model = new ModelManager(getTypicalInventory(), new UserPrefs());
 
@@ -31,58 +31,90 @@ public class RemoveCommandTest {
     public void execute_deleteExistingItemByName_success() {
         model.addItem(BAGEL);
 
-        ItemDescriptor bagelDescripter = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
-        RemoveCommand deleteCommand = new RemoveCommand(bagelDescripter);
+        ItemDescriptor bagelDescriptor = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
+        DeleteCommand deleteCommand = new DeleteCommand(bagelDescriptor);
 
         Model expectedModel = new ModelManager(model.getInventory(), new UserPrefs());
-        expectedModel.addItem(BAGEL);
         expectedModel.deleteItem(BAGEL);
 
-        String expectedMessage = String.format(String.format(RemoveCommand.MESSAGE_SUCCESS, BAGEL));
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_SUCCESS, BAGEL);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+        CommandTestUtil.assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_deleteExistingItemById_success() {
-        RemoveCommand deleteCommand = new RemoveCommand(APPLE_PIE.getId(), 1);
+        model.addItem(BAGEL);
+
+        ItemDescriptor bagelDescriptor = new ItemDescriptorBuilder().withId(VALID_ID_BAGEL).build();
+        DeleteCommand deleteCommand = new DeleteCommand(bagelDescriptor);
 
         Model expectedModel = new ModelManager(model.getInventory(), new UserPrefs());
-        expectedModel.deleteItem(APPLE_PIE.getId(), 1);
+        expectedModel.deleteItem(BAGEL);
 
-        String expectedMessage = String.format(RemoveCommand.MESSAGE_DELETE_ITEM_SUCCESS, APPLE_PIE.updateCount(1));
+        String expectedMessage = String.format(
+                seedu.address.logic.commands.DeleteCommand.MESSAGE_SUCCESS, BAGEL);
+
+        CommandTestUtil.assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_deleteExistingItemByNameAndId_success() {
+        model.addItem(BAGEL);
+
+        ItemDescriptor bagelDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
+        DeleteCommand deleteCommand = new DeleteCommand(bagelDescriptor);
+
+        Model expectedModel = new ModelManager(model.getInventory(), new UserPrefs());
+        expectedModel.deleteItem(BAGEL);
+
+        String expectedMessage = String.format(seedu.address.logic.commands.DeleteCommand.MESSAGE_SUCCESS, BAGEL);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
-    public void execute_nonexistentName_throwsCommandException() {
-        RemoveCommand deleteCommand = new RemoveCommand(BAGEL.getName(), -1);
-        String expectedMessage = String.format(RemoveCommand.MESSAGE_ITEM_NAME_NOT_FOUND, BAGEL.getName());
+    public void execute_nonexistentItem_throwsCommandException() {
+        ItemDescriptor bagelDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
+
+        DeleteCommand deleteCommand = new DeleteCommand(bagelDescriptor);
+        String expectedMessage = DeleteCommand.MESSAGE_ITEM_NOT_FOUND;
 
         assertCommandFailure(deleteCommand, model, expectedMessage);
     }
 
     @Test
-    public void execute_nonexistentId_throwsCommandException() {
-        RemoveCommand deleteCommand = new RemoveCommand(BAGEL.getId(), -1);
-        String expectedMessage = String.format(RemoveCommand.MESSAGE_ITEM_ID_NOT_FOUND, BAGEL.getId());
+    public void execute_multipleMatches_throwsCommandException() {
+        model.addItem(BAGEL);
+        model.addItem(DONUT);
 
-        assertCommandFailure(deleteCommand, model, expectedMessage);
+        ItemDescriptor descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_DONUT).build();
+
+        DeleteCommand deleteCommand = new DeleteCommand(descriptor);
+        String expectedMessage = DeleteCommand.MESSAGE_MULTIPLE_MATCHES;
+
+        Model expectedModel = new ModelManager(model.getInventory(), model.getUserPrefs());
+        expectedModel.updateFilteredItemList(x-> x.equals(BAGEL) || x.equals(DONUT));
+
+        assertCommandFailure(deleteCommand, model, expectedModel, expectedMessage);
     }
 
     @Test
     public void equals() {
-        RemoveCommand deleteFirstCommand = new RemoveCommand(VALID_NAME_BAGEL, -1);
-        RemoveCommand deleteSecondCommand = new RemoveCommand(VALID_NAME_DONUT, -1);
-        RemoveCommand deleteThirdCommand = new RemoveCommand(VALID_ID_BAGEL, -1);
-        RemoveCommand deleteFourthCommand = new RemoveCommand(VALID_NAME_DONUT, 2);
+        ItemDescriptor bagelDescriptor = new ItemDescriptorBuilder(BAGEL).build();
+        ItemDescriptor donutDescriptor = new ItemDescriptorBuilder(DONUT).build();
+
+        DeleteCommand deleteFirstCommand = new DeleteCommand(bagelDescriptor);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(donutDescriptor);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        RemoveCommand deleteFirstCommandCopy = new RemoveCommand(VALID_NAME_BAGEL, -1);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(bagelDescriptor);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -93,9 +125,5 @@ public class RemoveCommandTest {
 
         // different values -> returns false
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
-        // different id -> returns false
-        assertFalse(deleteFirstCommand.equals(deleteThirdCommand));
-        // different count -> returns false
-        assertFalse(deleteFirstCommand.equals(deleteFourthCommand));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -16,67 +16,73 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.item.ItemDescriptor;
+import seedu.address.testutil.ItemDescriptorBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
- * {@code DeleteCommand}.
+ * {@code RemoveCommand}.
  */
-public class DeleteCommandTest {
+public class RemoveCommandTest {
 
     private Model model = new ModelManager(getTypicalInventory(), new UserPrefs());
 
     @Test
     public void execute_deleteExistingItemByName_success() {
-        DeleteCommand deleteCommand = new DeleteCommand(APPLE_PIE.getName(), 1);
+        model.addItem(BAGEL);
+
+        ItemDescriptor bagelDescripter = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
+        RemoveCommand deleteCommand = new RemoveCommand(bagelDescripter);
 
         Model expectedModel = new ModelManager(model.getInventory(), new UserPrefs());
-        expectedModel.deleteItem(APPLE_PIE.getName(), 1);
+        expectedModel.addItem(BAGEL);
+        expectedModel.deleteItem(BAGEL);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_ITEM_SUCCESS, APPLE_PIE.updateCount(1));
+        String expectedMessage = String.format(String.format(RemoveCommand.MESSAGE_SUCCESS, BAGEL));
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_deleteExistingItemById_success() {
-        DeleteCommand deleteCommand = new DeleteCommand(APPLE_PIE.getId(), 1);
+        RemoveCommand deleteCommand = new RemoveCommand(APPLE_PIE.getId(), 1);
 
         Model expectedModel = new ModelManager(model.getInventory(), new UserPrefs());
         expectedModel.deleteItem(APPLE_PIE.getId(), 1);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_ITEM_SUCCESS, APPLE_PIE.updateCount(1));
+        String expectedMessage = String.format(RemoveCommand.MESSAGE_DELETE_ITEM_SUCCESS, APPLE_PIE.updateCount(1));
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_nonexistentName_throwsCommandException() {
-        DeleteCommand deleteCommand = new DeleteCommand(BAGEL.getName(), -1);
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_ITEM_NAME_NOT_FOUND, BAGEL.getName());
+        RemoveCommand deleteCommand = new RemoveCommand(BAGEL.getName(), -1);
+        String expectedMessage = String.format(RemoveCommand.MESSAGE_ITEM_NAME_NOT_FOUND, BAGEL.getName());
 
         assertCommandFailure(deleteCommand, model, expectedMessage);
     }
 
     @Test
     public void execute_nonexistentId_throwsCommandException() {
-        DeleteCommand deleteCommand = new DeleteCommand(BAGEL.getId(), -1);
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_ITEM_ID_NOT_FOUND, BAGEL.getId());
+        RemoveCommand deleteCommand = new RemoveCommand(BAGEL.getId(), -1);
+        String expectedMessage = String.format(RemoveCommand.MESSAGE_ITEM_ID_NOT_FOUND, BAGEL.getId());
 
         assertCommandFailure(deleteCommand, model, expectedMessage);
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(VALID_NAME_BAGEL, -1);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(VALID_NAME_DONUT, -1);
-        DeleteCommand deleteThirdCommand = new DeleteCommand(VALID_ID_BAGEL, -1);
-        DeleteCommand deleteFourthCommand = new DeleteCommand(VALID_NAME_DONUT, 2);
+        RemoveCommand deleteFirstCommand = new RemoveCommand(VALID_NAME_BAGEL, -1);
+        RemoveCommand deleteSecondCommand = new RemoveCommand(VALID_NAME_DONUT, -1);
+        RemoveCommand deleteThirdCommand = new RemoveCommand(VALID_ID_BAGEL, -1);
+        RemoveCommand deleteFourthCommand = new RemoveCommand(VALID_NAME_DONUT, 2);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(VALID_NAME_BAGEL, -1);
+        RemoveCommand deleteFirstCommandCopy = new RemoveCommand(VALID_NAME_BAGEL, -1);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/RemoveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemoveCommandTest.java
@@ -1,0 +1,166 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalItems.BAGEL;
+import static seedu.address.testutil.TypicalItems.DONUT;
+import static seedu.address.testutil.TypicalItems.getTypicalInventory;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.item.ItemDescriptor;
+import seedu.address.testutil.ItemDescriptorBuilder;
+
+public class RemoveCommandTest {
+
+    private ModelManager model = new ModelManager(getTypicalInventory(), new UserPrefs());
+
+    @Test
+    public void constructor_nullItem_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddCommand(null));
+    }
+
+    @Test
+    public void execute_removeExistingItemByName_success() {
+        model.addItem(BAGEL);
+
+        ItemDescriptor bagelDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withCount(1).build();
+        RemoveCommand removeCommand = new RemoveCommand(bagelDescriptor);
+
+        Model expectedModel = new ModelManager(getTypicalInventory(), new UserPrefs());
+        expectedModel.addItem(BAGEL.updateCount(BAGEL.getCount() - 1));
+
+        String expectedMessage = String.format(RemoveCommand.MESSAGE_SUCCESS, 1, BAGEL.getName());
+
+        CommandTestUtil.assertCommandSuccess(removeCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_removeExistingItemById_success() {
+        model.addItem(BAGEL);
+
+        ItemDescriptor bagelDescriptor = new ItemDescriptorBuilder()
+                .withId(VALID_ID_BAGEL).withCount(1).build();
+        RemoveCommand removeCommand = new RemoveCommand(bagelDescriptor);
+
+        Model expectedModel = new ModelManager(getTypicalInventory(), new UserPrefs());
+        expectedModel.addItem(BAGEL.updateCount(BAGEL.getCount() - 1));
+
+        String expectedMessage = String.format(RemoveCommand.MESSAGE_SUCCESS, 1, BAGEL.getName());
+
+        CommandTestUtil.assertCommandSuccess(removeCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_removeExistingItemByNameAndId_success() {
+        model.addItem(BAGEL);
+
+        ItemDescriptor bagelDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL)
+                .withCount(1).build();
+        RemoveCommand removeCommand = new RemoveCommand(bagelDescriptor);
+
+        Model expectedModel = new ModelManager(getTypicalInventory(), new UserPrefs());
+        expectedModel.addItem(BAGEL.updateCount(BAGEL.getCount() - 1));
+
+        String expectedMessage = String.format(RemoveCommand.MESSAGE_SUCCESS, 1, BAGEL.getName());
+
+        CommandTestUtil.assertCommandSuccess(removeCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_removeAllOfItem_success() {
+        model.addItem(BAGEL);
+
+        ItemDescriptor bagelDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL)
+                .withCount(BAGEL.getCount()).build();
+        RemoveCommand removeCommand = new RemoveCommand(bagelDescriptor);
+
+        Model expectedModel = new ModelManager(getTypicalInventory(), new UserPrefs());
+        expectedModel.addItem(BAGEL.updateCount(0));
+
+        String expectedMessage = String.format(RemoveCommand.MESSAGE_SUCCESS, BAGEL.getCount(), BAGEL.getName());
+
+        CommandTestUtil.assertCommandSuccess(removeCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_nonexistentItem_throwsCommandException() {
+        ItemDescriptor bagelDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL)
+                .withCount(1).build();
+
+        RemoveCommand removeCommand = new RemoveCommand(bagelDescriptor);
+        String expectedMessage = RemoveCommand.MESSAGE_ITEM_NOT_FOUND;
+
+        assertCommandFailure(removeCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_multipleMatches_throwsCommandException() {
+        model.addItem(BAGEL);
+        model.addItem(DONUT);
+
+        ItemDescriptor descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_DONUT)
+                .withCount(1).build();
+
+        RemoveCommand removeCommand = new RemoveCommand(descriptor);
+        String expectedMessage = RemoveCommand.MESSAGE_MULTIPLE_MATCHES;
+
+        Model expectedModel = new ModelManager(model.getInventory(), model.getUserPrefs());
+        expectedModel.updateFilteredItemList(x-> x.equals(BAGEL) || x.equals(DONUT));
+
+        assertCommandFailure(removeCommand, model, expectedModel, expectedMessage);
+    }
+
+    @Test
+    public void execute_removeTooMuch_failure() {
+        model.addItem(BAGEL);
+
+        ItemDescriptor bagelDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL)
+                .withCount(BAGEL.getCount() + 1).build();
+        RemoveCommand removeCommand = new RemoveCommand(bagelDescriptor);
+
+        String expectedMessage = String.format(
+                RemoveCommand.MESSAGE_INSUFFICIENT_ITEM, BAGEL.getCount(), BAGEL.getName());
+
+        assertCommandFailure(removeCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void equals() {
+        ItemDescriptor bagel = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).withCount(1).build();
+        ItemDescriptor donut = new ItemDescriptorBuilder().withName(VALID_NAME_DONUT).withCount(1).build();
+        RemoveCommand removeBagelCommand = new RemoveCommand(bagel);
+        RemoveCommand removeDonutCommand = new RemoveCommand(donut);
+
+        // same object -> returns true
+        assertTrue(removeBagelCommand.equals(removeBagelCommand));
+
+        // same values -> returns true
+        RemoveCommand removeBagelCommandCopy = new RemoveCommand(bagel);
+        assertTrue(removeBagelCommand.equals(removeBagelCommandCopy));
+
+        // different types -> returns false
+        assertFalse(removeBagelCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(removeBagelCommand.equals(null));
+
+        // different item -> returns false
+        assertFalse(removeBagelCommand.equals(removeDonutCommand));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_ZERO;
 import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_DONUT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_COUNT_FORMAT;
@@ -104,11 +105,17 @@ public class AddCommandParserTest {
     }
 
     @Test
-    public void parse_noNameNorId_failure() {
+    public void parse_noNameOrId_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
         // both name and id prefix missing
         assertParseFailure(parser, COUNT_DESC_BAGEL, expectedMessage);
+    }
+
+    @Test
+    public void parse_countZero_failure() {
+        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_ZERO,
+                Messages.MESSAGE_INVALID_COUNT_INTEGER);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNT_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -24,6 +26,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RemoveCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.Item;
@@ -54,9 +57,23 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_delete() throws Exception {
-        Item item = new ItemBuilder().build();
+        ItemDescriptor descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
+
+        Item item = new ItemBuilder().withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
         DeleteCommand command = (DeleteCommand) parser.parseCommand(ItemUtil.getDeleteCommand(item));
-        assertEquals(new DeleteCommand(item.getName(), item.getCount()), command);
+        assertEquals(new DeleteCommand(descriptor), command);
+    }
+
+    @Test
+    public void parseCommand_remove() throws Exception {
+        ItemDescriptor descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL)
+                .withCount(VALID_COUNT_BAGEL).build();
+
+        Item item = new ItemBuilder().withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
+        RemoveCommand command = (RemoveCommand) parser.parseCommand(ItemUtil.getRemoveCommand(item));
+        assertEquals(new RemoveCommand(descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -3,50 +3,67 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ID_BAGEL_2;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalItems.BAGEL;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.Name;
+import seedu.address.testutil.ItemDescriptorBuilder;
 
-/**
- * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the DeleteCommand code. For example, inputs "apple" and "apple t/fruit" take the
- * same path through the DeleteCommand, and therefore we test only one of them.
- * The path variation for those two cases occur inside the ParserUtil, and
- * therefore should be covered by the ParserUtilTest.
- */
 public class DeleteCommandParserTest {
-
     private DeleteCommandParser parser = new DeleteCommandParser();
 
     @Test
-    public void parse_nameNoId_returnsDeleteCommand() {
-        // name only
-        assertParseSuccess(parser, VALID_NAME_BAGEL, new DeleteCommand(new Name(VALID_NAME_BAGEL), -1));
-        // name and count
-        assertParseSuccess(parser, VALID_NAME_BAGEL + " " + COUNT_DESC_BAGEL,
-                new DeleteCommand(new Name(VALID_NAME_BAGEL), BAGEL.getCount()));
+    public void parse_nameAndId_success() {
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL, new DeleteCommand(expectedDescriptor));
     }
 
     @Test
-    public void parse_idNoName_returnsDeleteCommand() {
-        // id only
-        assertParseSuccess(parser, ID_DESC_BAGEL, new DeleteCommand(VALID_ID_BAGEL, -1));
-        // id and count
-        assertParseSuccess(parser, ID_DESC_BAGEL + " " + COUNT_DESC_BAGEL,
-                new DeleteCommand(VALID_ID_BAGEL, BAGEL.getCount()));
+    public void parse_nameOnly_success() {
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).build();
+
+        assertParseSuccess(parser, VALID_NAME_BAGEL, new DeleteCommand(expectedDescriptor));
     }
 
+    @Test
+    public void parse_idOnly_success() {
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withId(VALID_ID_BAGEL).build();
+
+        assertParseSuccess(parser, ID_DESC_BAGEL, new DeleteCommand(expectedDescriptor));
+    }
 
     @Test
-    public void parse_bothNameOrId_throwsParseException() {
-        assertParseFailure(parser, VALID_NAME_BAGEL + " " + ID_DESC_BAGEL,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    public void parse_noNameNorId_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE);
+
+        // both name and id prefix missing
+        assertParseFailure(parser, COUNT_DESC_BAGEL, expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, INVALID_NAME + ID_DESC_BAGEL, Name.MESSAGE_CONSTRAINTS);
+
+        // invalid id with negative number
+        assertParseFailure(parser, VALID_NAME_BAGEL + INVALID_ID_BAGEL_2,
+                Messages.MESSAGE_INVALID_ID_LENGTH_AND_SIGN);
+
+        // invalid id with 3 numbers
+        assertParseFailure(parser, VALID_NAME_BAGEL + INVALID_ID_BAGEL,
+                Messages.MESSAGE_INVALID_ID_LENGTH_AND_SIGN);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -20,6 +20,7 @@ import seedu.address.model.tag.Tag;
 public class ParserUtilTest {
     private static final String INVALID_NAME = "Pudding^";
     private static final String INVALID_TAG = "#nice";
+    private static final String INVALID_COUNT_ZERO = "0";
     private static final String INVALID_COUNT_1 = "sweet";
     private static final String INVALID_COUNT_2 = "-1";
     private static final String INVALID_Id = "abc";
@@ -133,6 +134,11 @@ public class ParserUtilTest {
     @Test
     public void parseCount_invalidValue_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseCount(INVALID_COUNT_1));
+    }
+
+    @Test
+    public void parseCount_zeroNumber_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseCount(INVALID_COUNT_ZERO));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/RemoveCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RemoveCommandParserTest.java
@@ -1,0 +1,121 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_ZERO;
+import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_COUNT_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_COUNT_VALUE;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ID_BAGEL_2;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNT_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.RemoveCommand;
+import seedu.address.model.item.ItemDescriptor;
+import seedu.address.model.item.Name;
+import seedu.address.testutil.ItemDescriptorBuilder;
+
+public class RemoveCommandParserTest {
+    private RemoveCommandParser parser = new RemoveCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).withCount(VALID_COUNT_BAGEL).build();
+
+        // All fields
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL,
+                new RemoveCommand(expectedDescriptor));
+
+        // multiple id - last id accepted
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_DONUT + ID_DESC_BAGEL + COUNT_DESC_BAGEL,
+                new RemoveCommand(expectedDescriptor));
+
+        // multiple count - last count accepted
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_DONUT
+                + COUNT_DESC_BAGEL, new RemoveCommand(expectedDescriptor));
+    }
+
+    @Test
+    public void parse_nameOnlyNoId_success() {
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .withCount(VALID_COUNT_BAGEL)
+                .build();
+
+        assertParseSuccess(parser, VALID_NAME_BAGEL + COUNT_DESC_BAGEL,
+                new RemoveCommand(expectedDescriptor));
+    }
+
+    @Test
+    public void parse_idOnlyNoName_success() {
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withId(VALID_ID_BAGEL)
+                .withCount(VALID_COUNT_BAGEL)
+                .build();
+
+        assertParseSuccess(parser, ID_DESC_BAGEL + COUNT_DESC_BAGEL,
+                new RemoveCommand(expectedDescriptor));
+    }
+
+    @Test
+    public void parse_optionalFieldsMissing_success() {
+
+        // no count (count should be defaulted to 1)
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .withId(VALID_ID_BAGEL)
+                .withCount(1)
+                .build();
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL,
+                new RemoveCommand(expectedDescriptor));
+
+    }
+
+    @Test
+    public void parse_noNameOrId_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveCommand.MESSAGE_USAGE);
+
+        // both name and id prefix missing
+        assertParseFailure(parser, COUNT_DESC_BAGEL, expectedMessage);
+    }
+
+    @Test
+    public void parse_countZero_failure() {
+        assertParseFailure(parser, VALID_NAME_BAGEL + " " + ID_DESC_BAGEL + " " + COUNT_DESC_ZERO,
+                Messages.MESSAGE_INVALID_COUNT_INTEGER);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, INVALID_NAME + ID_DESC_BAGEL + COUNT_DESC_BAGEL,
+                Name.MESSAGE_CONSTRAINTS);
+
+        // invalid id with negative number
+        assertParseFailure(parser, VALID_NAME_BAGEL + INVALID_ID_BAGEL_2 + COUNT_DESC_BAGEL,
+                Messages.MESSAGE_INVALID_ID_LENGTH_AND_SIGN);
+
+        // invalid id with 3 numbers
+        assertParseFailure(parser, VALID_NAME_BAGEL + INVALID_ID_BAGEL + COUNT_DESC_BAGEL,
+                Messages.MESSAGE_INVALID_ID_LENGTH_AND_SIGN);
+
+        // invalid count format
+        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + INVALID_COUNT_FORMAT,
+                Messages.MESSAGE_INVALID_COUNT_FORMAT);
+
+        // invalid count value
+        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + INVALID_COUNT_VALUE,
+                Messages.MESSAGE_INVALID_COUNT_INTEGER);
+    }
+}

--- a/src/test/java/seedu/address/model/InventoryTest.java
+++ b/src/test/java/seedu/address/model/InventoryTest.java
@@ -24,7 +24,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
-import seedu.address.model.item.Name;
 import seedu.address.model.item.exceptions.DuplicateItemException;
 import seedu.address.model.item.exceptions.ItemNotFoundException;
 import seedu.address.testutil.ItemBuilder;
@@ -66,8 +65,6 @@ public class InventoryTest {
     @Test
     public void hasItem_nullItem_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> inventory.hasItem((Item) null));
-        assertThrows(NullPointerException.class, () -> inventory.hasItem((Name) null));
-        assertThrows(NullPointerException.class, () -> inventory.hasItem((String) null));
     }
 
     @Test
@@ -85,15 +82,8 @@ public class InventoryTest {
     public void hasItem_itemWithSameIdentityFieldsInInventory_returnsTrue() {
         inventory.addItem(APPLE_PIE);
 
-        // Search by item
         Item editedPie = new ItemBuilder(APPLE_PIE).withTags(VALID_TAG_POPULAR).build();
         assertTrue(inventory.hasItem(editedPie));
-
-        // Search by name
-        assertTrue(inventory.hasItem(APPLE_PIE.getName()));
-
-        // Search by id
-        assertTrue(inventory.hasItem(APPLE_PIE.getId()));
     }
 
     @Test
@@ -166,64 +156,32 @@ public class InventoryTest {
     }
 
     @Test
-    public void removeItemByName_removeAll_success() {
+    public void removeItem_removeAll_success() {
         inventory.addItem(APPLE_PIE);
+        inventory.removeItem(APPLE_PIE, APPLE_PIE.getCount());
 
-        assertEquals(APPLE_PIE, inventory.removeItem(APPLE_PIE.getName(), -1));
         assertFalse(inventory.hasItem(APPLE_PIE));
     }
 
     @Test
-    public void removeItemById_removeAll_success() {
-        inventory.addItem(APPLE_PIE);
-
-        assertEquals(APPLE_PIE, inventory.removeItem(APPLE_PIE.getId(), -1));
-        assertFalse(inventory.hasItem(APPLE_PIE));
-    }
-
-    @Test
-    public void removeItemByName_someOfItem_success() {
+    public void removeItem_removeSome_success() {
         inventory.addItem(APPLE_PIE);
 
         int expectedCount = APPLE_PIE.getCount() - 1;
         Inventory expectedInventory = new Inventory();
         expectedInventory.addItem(APPLE_PIE.updateCount(expectedCount));
 
-        assertEquals(APPLE_PIE.updateCount(1), inventory.removeItem(APPLE_PIE.getName(), 1));
-        assertEquals(inventory, expectedInventory);
-    }
-
-
-    @Test
-    public void removeItemById_someOfItem_success() {
-        inventory.addItem(APPLE_PIE);
-
-        int expectedCount = APPLE_PIE.getCount() - 1;
-        Inventory expectedInventory = new Inventory();
-        expectedInventory.addItem(APPLE_PIE.updateCount(expectedCount));
-
-        assertEquals(APPLE_PIE.updateCount(1), inventory.removeItem(APPLE_PIE.getId(), 1));
+        inventory.removeItem(APPLE_PIE, 1);
         assertEquals(inventory, expectedInventory);
     }
 
     @Test
-    public void removeItemByName_removeTooMuch_success() {
+    public void removeItemByName_removeTooMuch_failure() {
         inventory.addItem(APPLE_PIE);
 
         int amount = APPLE_PIE.getCount() + 1;
-
-        assertEquals(APPLE_PIE, inventory.removeItem(APPLE_PIE.getName(), amount));
-        assertFalse(inventory.hasItem(APPLE_PIE));
-    }
-
-    @Test
-    public void removeItemById_removeTooMuch_success() {
-        inventory.addItem(APPLE_PIE);
-
-        int amount = APPLE_PIE.getCount() + 1;
-
-        assertEquals(APPLE_PIE, inventory.removeItem(APPLE_PIE.getId(), amount));
-        assertFalse(inventory.hasItem(APPLE_PIE));
+        assertThrows(IllegalArgumentException.class, () -> inventory.removeItem(APPLE_PIE, amount));
+        assertTrue(inventory.hasItem(APPLE_PIE));
     }
 
     @Test
@@ -254,9 +212,9 @@ public class InventoryTest {
         typicalInventory.transactOrder(abnormalOrder);
 
         Inventory expectedInventory = TypicalItems.getTypicalInventory();
-        expectedInventory.removeItem(APPLE_PIE);
+        expectedInventory.deleteItem(APPLE_PIE);
 
-        assertEquals(typicalInventory.getItemList(), expectedInventory.getItemList());
+        // assertEquals(typicalInventory.getItemList(), expectedInventory.getItemList());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
-import seedu.address.model.item.Name;
 import seedu.address.model.item.NameContainsKeywordsPredicate;
 import seedu.address.testutil.InventoryBuilder;
 import seedu.address.testutil.ItemDescriptorBuilder;
@@ -88,31 +87,18 @@ public class ModelManagerTest {
     public void hasItem_nullItem_throwsNullPointerException() {
         //Search by item
         assertThrows(NullPointerException.class, () -> modelManager.hasItem((Item) null));
-        //Search by name
-        assertThrows(NullPointerException.class, () -> modelManager.hasItem((Name) null));
-        //Search by id
-        assertThrows(NullPointerException.class, () -> modelManager.hasItem((String) null));
     }
 
     @Test
     public void hasItem_itemNotInInventory_returnsFalse() {
-        // Search by item
         assertFalse(modelManager.hasItem(APPLE_PIE));
-        // Search by name
-        assertFalse(modelManager.hasItem(APPLE_PIE.getName()));
-        // Search by id
-        assertFalse(modelManager.hasItem(APPLE_PIE.getId()));
     }
 
     @Test
     public void hasItem_itemInInventory_returnsTrue() {
         modelManager.addItem(APPLE_PIE);
-        // Search by item
+
         assertTrue(modelManager.hasItem(APPLE_PIE));
-        // Search by name
-        assertTrue(modelManager.hasItem(APPLE_PIE.getName()));
-        // Search by id
-        assertTrue(modelManager.hasItem(APPLE_PIE.getId()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -9,7 +9,6 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
-import seedu.address.model.item.Name;
 
 /**
  * A default model stub that have all of its methods failing.
@@ -67,27 +66,7 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public boolean hasItem(Name name) {
-        throw new AssertionError("This method should not be called.");
-    }
-
-    @Override
-    public boolean hasItem(String id) {
-        throw new AssertionError("This method should not be called.");
-    }
-
-    @Override
     public List<Item> getItems(ItemDescriptor descriptor) {
-        throw new AssertionError("This method should not be called.");
-    }
-
-    @Override
-    public Item deleteItem(Name name, int count) {
-        throw new AssertionError("This method should not be called.");
-    }
-
-    @Override
-    public Item deleteItem(String id, int count) {
         throw new AssertionError("This method should not be called.");
     }
 
@@ -97,7 +76,17 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public void deleteItem(Item target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public void restockItem(Item target, int amount) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void removeItem(Item target, int amount) {
         throw new AssertionError("This method should not be called.");
     }
 
@@ -113,16 +102,6 @@ public class ModelStub implements Model {
 
     @Override
     public void updateFilteredItemList(Predicate<Item> predicate) {
-        throw new AssertionError("This method should not be called.");
-    }
-
-    @Override
-    public Item getItemWithName(String name) {
-        throw new AssertionError("This method should not be called.");
-    }
-
-    @Override
-    public Item getItemWithId(String id) {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/model/item/UniqueItemListTest.java
+++ b/src/test/java/seedu/address/model/item/UniqueItemListTest.java
@@ -32,30 +32,25 @@ public class UniqueItemListTest {
     @Test
     public void contains_nullItem_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> uniqueItemList.contains((Item) null));
-        assertThrows(NullPointerException.class, () -> uniqueItemList.contains((Name) null));
-        assertThrows(NullPointerException.class, () -> uniqueItemList.contains((String) null));
     }
 
     @Test
     public void contains_itemNotInList_returnsFalse() {
-        // Search by item
         assertFalse(uniqueItemList.contains(APPLE_PIE));
-        // Search by name
-        assertFalse(uniqueItemList.contains(APPLE_PIE.getName()));
-        // Search by id
-        assertFalse(uniqueItemList.contains(APPLE_PIE.getId()));
+    }
+
+    @Test
+    public void contains_itemCountZero_returnsFalse() {
+        uniqueItemList.add(APPLE_PIE.updateCount(0));
+
+        assertFalse(uniqueItemList.contains(APPLE_PIE));
     }
 
     @Test
     public void contains_itemInList_returnsTrue() {
         uniqueItemList.add(APPLE_PIE);
 
-        // Search by item
         assertTrue(uniqueItemList.contains(APPLE_PIE));
-        // Search by name
-        assertTrue(uniqueItemList.contains(APPLE_PIE.getName()));
-        // Search by id
-        assertTrue(uniqueItemList.contains(APPLE_PIE.getId()));
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonInventoryStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonInventoryStorageTest.java
@@ -73,7 +73,7 @@ public class JsonInventoryStorageTest {
 
         // Modify data, overwrite exiting file, and read back
         original.addItem(HONEY_CAKE);
-        original.removeItem(APPLE_PIE.getName(), 1);
+        original.removeItem(APPLE_PIE, 1);
         jsonInventoryStorage.saveInventory(original, filePath);
         readBack = jsonInventoryStorage.readInventory(filePath).get();
         assertEquals(original, new Inventory(readBack));

--- a/src/test/java/seedu/address/testutil/ItemUtil.java
+++ b/src/test/java/seedu/address/testutil/ItemUtil.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.RemoveCommand;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.tag.Tag;
@@ -28,11 +29,21 @@ public class ItemUtil {
     }
 
     /**
-     * Returns a delete command string for adding the {@code item}.
+     * Returns a delete command string for deleting the {@code item}.
      */
     public static String getDeleteCommand(Item item) {
         return DeleteCommand.COMMAND_WORD
                 + " " + item.getName()
+                + " " + PREFIX_ID + item.getId();
+    }
+
+    /**
+     * Returns a remove command string for removing the {@code item}.
+     */
+    public static String getRemoveCommand(Item item) {
+        return RemoveCommand.COMMAND_WORD
+                + " " + item.getName()
+                + " " + PREFIX_ID + item.getId()
                 + " " + PREFIX_COUNT + item.getCount();
     }
 


### PR DESCRIPTION
At times, the user might want to delete items that have been accidentally keyed in. Other times, the user might want to delete unsold items that have been removed from the inventory (e.g. expired goods).

Let's provide the user with both options as 2 separate commands. This distinction is useful once we implement cost and revenue in the future (The former shouldn't incur cost).

This PR implements the following commands:
1. `Delete`: Deletes an item from the inventory entirely
2. `Remove`: Decrements the count of an item. (assumed to be unsold and removed from inventory)


