### PR TITLE
Enhance order commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -57,6 +57,7 @@ public class AddCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        assert(toAddDescriptor.getCount().isPresent());
 
         List<Item> matchingItems = model.getItems(toAddDescriptor);
 

--- a/src/main/java/seedu/address/logic/commands/AddToOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddToOrderCommand.java
@@ -7,6 +7,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
+
+import java.util.List;
 
 /**
  * Adds item to the order list.
@@ -16,26 +19,27 @@ public class AddToOrderCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an item to current order list. "
             + "Parameters: "
-            + PREFIX_NAME + "NAME "
+            + "NAME "
             + PREFIX_COUNT + "COUNT "
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "Milk "
+            + "Milk "
             + PREFIX_COUNT + "10 ";
 
 
     public static final String MESSAGE_SUCCESS = " has been added to order.";
-
+    public static final String MESSAGE_ITEM_NOT_FOUND = "No such item in the inventory";
     public static final String MESSAGE_NO_UNCLOSED_ORDER = "Please use `sorder` to enter ordering mode first.";
+    public static final String MESSAGE_MULTIPLE_MATCHES =
+            "Multiple candidates found, check item's details again?";
 
-
-    private Item itemToAdd;
+    private final ItemDescriptor toAddDescriptor;
 
     /**
      * Instantiates a command to add {@code Item} to the current {@code Order}
      */
-    public AddToOrderCommand(Item item) {
-        requireNonNull(item);
-        itemToAdd = item;
+    public AddToOrderCommand(ItemDescriptor toAddDescriptor) {
+        requireNonNull(toAddDescriptor);
+        this.toAddDescriptor = toAddDescriptor;
     }
 
     /**
@@ -48,13 +52,27 @@ public class AddToOrderCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        assert(toAddDescriptor.getCount().isPresent());
 
-        if (model.hasUnclosedOrder()) {
-            model.addToOrder(itemToAdd);
-            return new CommandResult(itemToAdd.getName() + MESSAGE_SUCCESS);
-        } else {
+        if (!model.hasUnclosedOrder()) {
             // Not in ordering mode, tell user to enter ordering mode first.
             return new CommandResult(MESSAGE_NO_UNCLOSED_ORDER);
         }
+
+        List<Item> matchingItems = model.getItems(toAddDescriptor);
+
+        // Check if item exists in inventory
+        if (matchingItems.size() == 0) {
+            throw new CommandException(MESSAGE_ITEM_NOT_FOUND);
+        }
+
+        // Check that only 1 item fit the description
+        if (matchingItems.size() > 1) {
+            model.updateFilteredItemList(toAddDescriptor::isMatch);
+            throw new CommandException(MESSAGE_MULTIPLE_MATCHES);
+        }
+
+        model.addToOrder(matchingItems.get(0).updateCount(toAddDescriptor.getCount().get()));
+        return new CommandResult(toAddDescriptor.getName() + MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddToOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddToOrderCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -20,6 +21,7 @@ public class AddToOrderCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an item to current order list. "
             + "Parameters: "
             + "NAME "
+            + "Or " + PREFIX_ID + "ID"
             + PREFIX_COUNT + "COUNT "
             + "Example: " + COMMAND_WORD + " "
             + "Milk "

--- a/src/main/java/seedu/address/logic/commands/AddToOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddToOrderCommand.java
@@ -3,14 +3,13 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.List;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
-
-import java.util.List;
 
 /**
  * Adds item to the order list.
@@ -28,11 +27,11 @@ public class AddToOrderCommand extends Command {
             + PREFIX_COUNT + "10 ";
 
 
-    public static final String MESSAGE_SUCCESS = " has been added to order.";
+    public static final String MESSAGE_SUCCESS = "Items added to order: %d x %s";
     public static final String MESSAGE_ITEM_NOT_FOUND = "No such item in the inventory";
     public static final String MESSAGE_NO_UNCLOSED_ORDER = "Please use `sorder` to enter ordering mode first.";
     public static final String MESSAGE_MULTIPLE_MATCHES =
-            "Multiple candidates found, check item's details again?";
+            "Multiple candidates found, which one do you mean to add?";
 
     private final ItemDescriptor toAddDescriptor;
 
@@ -58,7 +57,7 @@ public class AddToOrderCommand extends Command {
 
         if (!model.hasUnclosedOrder()) {
             // Not in ordering mode, tell user to enter ordering mode first.
-            return new CommandResult(MESSAGE_NO_UNCLOSED_ORDER);
+            throw new CommandException(MESSAGE_NO_UNCLOSED_ORDER);
         }
 
         List<Item> matchingItems = model.getItems(toAddDescriptor);
@@ -74,7 +73,16 @@ public class AddToOrderCommand extends Command {
             throw new CommandException(MESSAGE_MULTIPLE_MATCHES);
         }
 
-        model.addToOrder(matchingItems.get(0).updateCount(toAddDescriptor.getCount().get()));
-        return new CommandResult(toAddDescriptor.getName() + MESSAGE_SUCCESS);
+        Item toAddItem = matchingItems.get(0).updateCount(toAddDescriptor.getCount().get());
+        model.addToOrder(toAddItem);
+        return new CommandResult(
+                String.format(MESSAGE_SUCCESS, toAddItem.getCount(), toAddItem.getName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddToOrderCommand // instanceof handles nulls
+                && toAddDescriptor.equals(((AddToOrderCommand) other).toAddDescriptor));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/RemoveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveCommand.java
@@ -45,6 +45,7 @@ public class RemoveCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        assert(toRemoveDescriptor.getCount().isPresent());
 
         List<Item> matchingItems = model.getItems(toRemoveDescriptor);
 

--- a/src/main/java/seedu/address/logic/commands/RemoveFromOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveFromOrderCommand.java
@@ -1,36 +1,48 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 
+import java.util.List;
+
+/**
+ * Removes an item from the order list.
+ */
 public class RemoveFromOrderCommand extends Command {
     public static final String COMMAND_WORD = "corder";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Removes an item from current order list . "
             + "Parameters: "
-            + PREFIX_NAME + "NAME "
+            + "NAME "
+            + "Or " + PREFIX_ID + "ID"
+            + PREFIX_COUNT + "COUNT "
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "Milk ";
+            + "Milk "
+            + PREFIX_COUNT + "10 ";
 
 
     public static final String MESSAGE_SUCCESS = " has been removed from order.";
-
+    public static final String MESSAGE_ITEM_NOT_FOUND = "Item is not in the current order";
+    public static final String MESSAGE_INSUFFICIENT_ITEM = "There isn't that much of the item in the current order";
     public static final String MESSAGE_NO_UNCLOSED_ORDER = "Please use `sorder` to enter ordering mode first.";
+    public static final String MESSAGE_MULTIPLE_MATCHES =
+            "Multiple candidates found, check item's details again?";
 
-
-    private Item itemToRemove;
+    private final ItemDescriptor toRemoveDescriptor;
 
     /**
      * Instantiates a command to remove {@code Item} from the current {@code Order}
      */
-    public RemoveFromOrderCommand(Item item) {
-        requireNonNull(item);
+    public RemoveFromOrderCommand(ItemDescriptor toRemoveDescriptor) {
+        requireNonNull(toRemoveDescriptor);
 
-        itemToRemove = item;
+        this.toRemoveDescriptor = toRemoveDescriptor;
     }
 
     /**
@@ -44,12 +56,23 @@ public class RemoveFromOrderCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasUnclosedOrder()) {
-            model.removeFromOrder(itemToRemove);
-            return new CommandResult(itemToRemove.getName() + MESSAGE_SUCCESS);
-        } else {
+        if (!model.hasUnclosedOrder()) {
             // Not in ordering mode, tell user to enter ordering mode first.
             return new CommandResult(MESSAGE_NO_UNCLOSED_ORDER);
         }
+
+        List<Item> matchingItems = model.getFromOrder(toRemoveDescriptor);
+
+        // Check if item exists in inventory
+        if (matchingItems.size() == 0) {
+            throw new CommandException(MESSAGE_ITEM_NOT_FOUND);
+        }
+
+        // Check that only 1 item fit the description
+        if (matchingItems.size() > 1) {
+            model.updateFilteredItemList(toRemoveDescriptor::isMatch);
+            throw new CommandException(MESSAGE_MULTIPLE_MATCHES);
+        }
+
     }
 }

--- a/src/main/java/seedu/address/logic/commands/RemoveFromOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveFromOrderCommand.java
@@ -4,12 +4,12 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 
+import java.util.List;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemDescriptor;
-
-import java.util.List;
 
 /**
  * Removes an item from the order list.
@@ -27,7 +27,7 @@ public class RemoveFromOrderCommand extends Command {
             + PREFIX_COUNT + "10 ";
 
 
-    public static final String MESSAGE_SUCCESS = " has been removed from order.";
+    public static final String MESSAGE_SUCCESS = "Item removed from order: %d x %s";
     public static final String MESSAGE_ITEM_NOT_FOUND = "Item is not in the current order";
     public static final String MESSAGE_INSUFFICIENT_ITEM = "There isn't that much of the item in the current order";
     public static final String MESSAGE_NO_UNCLOSED_ORDER = "Please use `sorder` to enter ordering mode first.";
@@ -58,21 +58,40 @@ public class RemoveFromOrderCommand extends Command {
 
         if (!model.hasUnclosedOrder()) {
             // Not in ordering mode, tell user to enter ordering mode first.
-            return new CommandResult(MESSAGE_NO_UNCLOSED_ORDER);
+            throw new CommandException(MESSAGE_NO_UNCLOSED_ORDER);
         }
 
         List<Item> matchingItems = model.getFromOrder(toRemoveDescriptor);
 
-        // Check if item exists in inventory
+        // Check if item exists in order
         if (matchingItems.size() == 0) {
             throw new CommandException(MESSAGE_ITEM_NOT_FOUND);
         }
 
         // Check that only 1 item fit the description
         if (matchingItems.size() > 1) {
-            model.updateFilteredItemList(toRemoveDescriptor::isMatch);
+            // TODO: ensure compatible with the View Order update
+            //model.updateFilteredItemList(toRemoveDescriptor::isMatch);
             throw new CommandException(MESSAGE_MULTIPLE_MATCHES);
         }
 
+        Item target = matchingItems.get(0);
+        int amount = toRemoveDescriptor.getCount().get();
+        // Check that enough of item to remove
+        if (target.getCount() < amount) {
+            throw new CommandException(
+                    String.format(MESSAGE_INSUFFICIENT_ITEM, target.getCount(), target.getName())
+            );
+        }
+
+        model.removeFromOrder(target, amount);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, amount, target.getName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RemoveFromOrderCommand // instanceof handles nulls
+                && toRemoveDescriptor.equals(((RemoveFromOrderCommand) other).toRemoveDescriptor));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddToOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddToOrderCommandParser.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.commands.AddToOrderCommand;
-import seedu.address.logic.commands.RemoveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.ItemDescriptor;
 
@@ -24,7 +23,7 @@ public class AddToOrderCommandParser implements Parser<AddToOrderCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_COUNT, PREFIX_TAG);
 
         if (argMultimap.getValue(PREFIX_ID).isEmpty() && argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddToOrderCommand.MESSAGE_USAGE));
         }
 
         ItemDescriptor toAddDescriptor = new ItemDescriptor();

--- a/src/main/java/seedu/address/logic/parser/AddToOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddToOrderCommandParser.java
@@ -3,79 +3,47 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Stream;
-
-import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.AddToOrderCommand;
+import seedu.address.logic.commands.RemoveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.item.Item;
-import seedu.address.model.item.Name;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.item.ItemDescriptor;
 
+/**
+ * Parses input arguments and creates a new AddToOrderCommand object
+ */
 public class AddToOrderCommandParser implements Parser<AddToOrderCommand> {
-    private static final Double DUMMY_PRICE = 1.0;
+
     /**
      * Parses {@code userInput} into a {@code AddToOrderCommand} and returns it.
      */
     @Override
     public AddToOrderCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ID, PREFIX_COUNT);
+                ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_COUNT, PREFIX_TAG);
 
-        if (!(isNameOrIdPresent(argMultimap) && isCountPresent(argMultimap))
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddToOrderCommand.MESSAGE_USAGE));
+        if (argMultimap.getValue(PREFIX_ID).isEmpty() && argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveCommand.MESSAGE_USAGE));
         }
 
-        Name name;
-        Integer id;
-        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            // Use name as long as name is given.
-            name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-            id = Integer.parseInt(UUID.randomUUID().toString());
+        ItemDescriptor toAddDescriptor = new ItemDescriptor();
+
+        // Parse name
+        if (!argMultimap.getPreamble().isEmpty()) {
+            toAddDescriptor.setName(ParserUtil.parseName(argMultimap.getPreamble()));
+        }
+        // Parse Id
+        if (argMultimap.getValue(PREFIX_ID).isPresent()) {
+            toAddDescriptor.setId(ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get()));
+        }
+        // Parse count
+        if (argMultimap.getValue(PREFIX_COUNT).isPresent()) {
+            toAddDescriptor.setCount(ParserUtil.parseCount(argMultimap.getValue(PREFIX_COUNT).get()));
         } else {
-            // Use ID if only ID is given.
-            name = new Name(StringUtil.generateRandomString());
-            id = Integer.parseInt(argMultimap.getValue(PREFIX_ID).get());
+            toAddDescriptor.setCount(1);
         }
 
-        Integer count = ParserUtil.parseCount(argMultimap.getValue(PREFIX_COUNT).get());
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        // TODO STILL IMPLEMENTED USING DUMMY_PRICE
-        Double costPrice = DUMMY_PRICE;
-        Double salesPrice = DUMMY_PRICE;
-
-        Item item = new Item(name, id, count, tagList, costPrice, salesPrice);
-
-        return new AddToOrderCommand(item);
-    }
-
-    /**
-     * Returns true if {@code PREFIX_NAME} or {@code PREFIX_COUNT} is present.
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean isNameOrIdPresent(ArgumentMultimap argumentMultimap) {
-        return arePrefixesPresent(argumentMultimap, PREFIX_NAME) || arePrefixesPresent(argumentMultimap, PREFIX_ID);
-    }
-
-    /**
-     * Returns true if {@code PREFIX_COUNT} is present.
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean isCountPresent(ArgumentMultimap argumentMultimap) {
-        return arePrefixesPresent(argumentMultimap, PREFIX_COUNT);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+        return new AddToOrderCommand(toAddDescriptor);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -35,7 +35,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         }
 
         // Parse id
-        if (!argMultimap.getValue(PREFIX_ID).isEmpty()) {
+        if (argMultimap.getValue(PREFIX_ID).isPresent()) {
             toDeleteDescriptor.setId(ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get()));
         }
 

--- a/src/main/java/seedu/address/logic/parser/RemoveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveCommandParser.java
@@ -27,24 +27,24 @@ public class RemoveCommandParser implements Parser<RemoveCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveCommand.MESSAGE_USAGE));
         }
 
-        ItemDescriptor toAddDescriptor = new ItemDescriptor();
+        ItemDescriptor toRemoveDescriptor = new ItemDescriptor();
 
         // Parse name
         if (!argMultimap.getPreamble().isEmpty()) {
-            toAddDescriptor.setName(ParserUtil.parseName(argMultimap.getPreamble()));
+            toRemoveDescriptor.setName(ParserUtil.parseName(argMultimap.getPreamble()));
         }
         // Parse Id
         if (argMultimap.getValue(PREFIX_ID).isPresent()) {
-            toAddDescriptor.setId(ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get()));
+            toRemoveDescriptor.setId(ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get()));
         }
         // Parse count
         if (argMultimap.getValue(PREFIX_COUNT).isPresent()) {
-            toAddDescriptor.setCount(ParserUtil.parseCount(argMultimap.getValue(PREFIX_COUNT).get()));
+            toRemoveDescriptor.setCount(ParserUtil.parseCount(argMultimap.getValue(PREFIX_COUNT).get()));
         } else {
-            toAddDescriptor.setCount(1);
+            toRemoveDescriptor.setCount(1);
         }
 
-        return new RemoveCommand(toAddDescriptor);
+        return new RemoveCommand(toRemoveDescriptor);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/RemoveFromOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveFromOrderCommandParser.java
@@ -1,74 +1,49 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Stream;
-
-import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.RemoveFromOrderCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.item.Item;
-import seedu.address.model.item.Name;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.item.ItemDescriptor;
 
 public class RemoveFromOrderCommandParser implements Parser<RemoveFromOrderCommand> {
-    private static final int DUMMY_COUNT = -1;
-    private static final double DUMMY_PRICE = 1.0;
 
     /**
-     * Parses {@code userInput} into a {@code AddToOrderCommand} and returns it.
+     * Parses {@code userInput} into a {@code RemoveFromOrderCommand} and returns it.
      */
     @Override
     public RemoveFromOrderCommand parse(String args) throws ParseException {
+
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ID);
+                ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_COUNT, PREFIX_TAG);
 
-        if (!(isNameOrIdPresent(argMultimap))
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(
-                    MESSAGE_INVALID_COMMAND_FORMAT, RemoveFromOrderCommand.MESSAGE_USAGE));
+        if (argMultimap.getValue(PREFIX_ID).isEmpty() && argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveFromOrderCommand.MESSAGE_USAGE)
+            );
         }
 
-        Name name;
-        Integer id;
-        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            // Use name as long as name is given.
-            name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-            id = Integer.parseInt(UUID.randomUUID().toString());
+        ItemDescriptor toRemoveDescriptor = new ItemDescriptor();
+
+        // Parse name
+        if (!argMultimap.getPreamble().isEmpty()) {
+            toRemoveDescriptor.setName(ParserUtil.parseName(argMultimap.getPreamble()));
+        }
+        // Parse Id
+        if (argMultimap.getValue(PREFIX_ID).isPresent()) {
+            toRemoveDescriptor.setId(ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get()));
+        }
+        // Parse count
+        if (argMultimap.getValue(PREFIX_COUNT).isPresent()) {
+            toRemoveDescriptor.setCount(ParserUtil.parseCount(argMultimap.getValue(PREFIX_COUNT).get()));
         } else {
-            // Use ID if only ID is given.
-            name = new Name(StringUtil.generateRandomString());
-            id = Integer.parseInt(argMultimap.getValue(PREFIX_ID).get());
+            toRemoveDescriptor.setCount(1);
         }
 
-        Integer count = DUMMY_COUNT;
-        Double costPrice = DUMMY_PRICE;
-        Double salesPrice = DUMMY_PRICE;
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-
-        Item item = new Item(name, id, count, tagList, costPrice, salesPrice);
-
-        return new RemoveFromOrderCommand(item);
+        return new RemoveFromOrderCommand(toRemoveDescriptor);
     }
 
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean isNameOrIdPresent(ArgumentMultimap argumentMultimap) {
-        return arePrefixesPresent(argumentMultimap, PREFIX_NAME) || arePrefixesPresent(argumentMultimap, PREFIX_ID);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
 }

--- a/src/main/java/seedu/address/model/Inventory.java
+++ b/src/main/java/seedu/address/model/Inventory.java
@@ -14,7 +14,7 @@ import seedu.address.model.order.TransactionRecord;
 
 /**
  * Wraps all data at the inventory level
- * Duplicates are not allowed (by .isSameItem comparison)
+ * Duplicates are aggregated by adjusting count (by .isSameItem comparison)
  */
 public class Inventory implements ReadOnlyInventory {
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -126,11 +126,11 @@ public interface Model {
     void addToOrder(Item item);
 
     /**
-     * Removes the item from the current order list.
-     *
-     * @param item
+     * Decrements the count of the given {@code target} in the order by {@code amount}.
+     * {@code target} must exist in the order.
+     * {@code amount} must be less than {@code target}'s count.
      */
-    void removeFromOrder(Item item);
+    void removeFromOrder(Item target, int amount);
 
     /**
      * Returns the items in the order that match the {@code itemDescriptor}.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -133,6 +133,12 @@ public interface Model {
     void removeFromOrder(Item item);
 
     /**
+     * Returns the items in the order that match the {@code itemDescriptor}.
+     * @see ItemDescriptor#isMatch(Item)
+     */
+    public List<Item> getFromOrder(ItemDescriptor itemDescriptor);
+
+    /**
      * Destroys the current order when ordering finish.
      */
     void transactAndClearOrder();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -219,9 +219,9 @@ public class ModelManager implements Model {
     @Override
     public void addToOrder(Item item) {
         requireNonNull(item);
-        assert hasUnclosedOrder();
+        assert(hasUnclosedOrder());
 
-        optionalOrder.get().addItem(item);
+        optionalOrder.ifPresent(order -> order.addItem(item));
     }
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -189,9 +189,6 @@ public class ModelManager implements Model {
 
     // ============== Order related methods ========================
 
-    /**
-     * Sets the current order of the model.
-     */
     @Override
     public void setOrder(Order order) {
         requireNonNull(order);
@@ -205,17 +202,11 @@ public class ModelManager implements Model {
         return optionalOrder.get();
     }
 
-    /**
-     * Returns a boolean that the model has an unclosed order or not.
-     */
     @Override
     public boolean hasUnclosedOrder() {
         return optionalOrder.isPresent();
     }
 
-    /**
-     * Adds item to the current order list.
-     */
     @Override
     public void addToOrder(Item item) {
         requireNonNull(item);
@@ -224,32 +215,22 @@ public class ModelManager implements Model {
         optionalOrder.ifPresent(order -> order.addItem(item));
     }
 
-    /**
-     * Returns the items in the order that match the {@code itemDescriptor}.
-     * @see ItemDescriptor#isMatch(Item) 
-     */
     @Override
     public List<Item> getFromOrder(ItemDescriptor itemDescriptor) {
         requireNonNull(itemDescriptor);
         assert hasUnclosedOrder();
 
-        optionalOrder.map(order -> order.getItems(itemDescriptor)).get();
+        return optionalOrder.map(order -> order.getItems(itemDescriptor)).get();
     }
 
-    /**
-     * Removes the item from the current order list.
-     */
     @Override
-    public void removeFromOrder(Item item) {
+    public void removeFromOrder(Item item, int amount) {
         requireNonNull(item);
         assert hasUnclosedOrder();
 
-        optionalOrder.ifPresent(order -> order.removeItem(item));
+        optionalOrder.ifPresent(order -> order.removeItem(item, amount));
     }
 
-    /**
-     * Updates the inventory according to current order and exit ordering mode, the transaction is recorded as well.
-     */
     @Override
     public void transactAndClearOrder() {
         assert hasUnclosedOrder();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -219,9 +219,21 @@ public class ModelManager implements Model {
     @Override
     public void addToOrder(Item item) {
         requireNonNull(item);
-        assert(hasUnclosedOrder());
+        assert hasUnclosedOrder();
 
         optionalOrder.ifPresent(order -> order.addItem(item));
+    }
+
+    /**
+     * Returns the items in the order that match the {@code itemDescriptor}.
+     * @see ItemDescriptor#isMatch(Item) 
+     */
+    @Override
+    public List<Item> getFromOrder(ItemDescriptor itemDescriptor) {
+        requireNonNull(itemDescriptor);
+        assert hasUnclosedOrder();
+
+        optionalOrder.map(order -> order.getItems(itemDescriptor)).get();
     }
 
     /**
@@ -232,7 +244,7 @@ public class ModelManager implements Model {
         requireNonNull(item);
         assert hasUnclosedOrder();
 
-        optionalOrder.get().removeItem(item);
+        optionalOrder.ifPresent(order -> order.removeItem(item));
     }
 
     /**

--- a/src/main/java/seedu/address/model/item/ItemDescriptor.java
+++ b/src/main/java/seedu/address/model/item/ItemDescriptor.java
@@ -25,6 +25,18 @@ public class ItemDescriptor {
     }
 
     /**
+     * Construct an {@code ItemDescriptor} that corresponds with the given {@code Item}
+     */
+    public ItemDescriptor(Item toCopy) {
+        setName(toCopy.getName());
+        setId(toCopy.getId());
+        setCount(toCopy.getCount());
+        setCostPrice(toCopy.getCostPrice());
+        setSalesPrice(toCopy.getSalesPrice());
+        setTags(toCopy.getTags());
+    }
+
+    /**
      * Copy constructor.
      * A defensive copy of {@code tags} is used internally.
      */

--- a/src/main/java/seedu/address/model/order/Order.java
+++ b/src/main/java/seedu/address/model/order/Order.java
@@ -64,6 +64,15 @@ public class Order {
     }
 
     /**
+     * Returns list of items in the inventory that matches the given {@code ItemDescriptor}
+     * @see ItemDescriptor#isMatch(Item)
+     */
+    public List<Item> getItems(ItemDescriptor descriptor) {
+        requireNonNull(descriptor);
+        return items.get(descriptor);
+    }
+
+    /**
      * Gets a list of items in the order.
      */
     public ObservableList<Item> getOrderItems() {

--- a/src/main/java/seedu/address/model/order/Order.java
+++ b/src/main/java/seedu/address/model/order/Order.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.item.UniqueItemList;
 
 /**
@@ -35,9 +36,16 @@ public class Order {
      * Add an {@code Item} to the order.
      */
     public void addItem(Item newItem) {
-        // TODO: Implement count increasing to duplicate item adding.
         requireNonNull(newItem);
-        items.add(newItem);
+
+        if (!items.contains(newItem)) {
+            items.add(newItem);
+        }
+
+        Item existingItem = items.get(new ItemDescriptor(newItem)).get(0);
+
+        int newCount = existingItem.getCount() + newItem.getCount();
+        items.setItem(existingItem, existingItem.updateCount(newCount));
     }
 
     /**

--- a/src/main/java/seedu/address/model/order/Order.java
+++ b/src/main/java/seedu/address/model/order/Order.java
@@ -40,6 +40,7 @@ public class Order {
 
         if (!items.contains(newItem)) {
             items.add(newItem);
+            return;
         }
 
         Item existingItem = items.get(new ItemDescriptor(newItem)).get(0);
@@ -50,16 +51,24 @@ public class Order {
 
     /**
      * Remove the specified {@code Item} from order.
+     * {@code target} must exist in the inventory.
+     * @throws IllegalArgumentException if {@code target}'s count less than amount.
      */
-    public void removeItem(Item toBeRemoved) {
-        requireNonNull(toBeRemoved);
+    public void removeItem(Item target, int amount) {
+        requireNonNull(target);
+        assert(amount > 0);
 
-        for (Item item : items.asUnmodifiableObservableList()) {
-            if (item.isSameItem(toBeRemoved)) { // Same name OR same id
-                items.remove(item);
-                break;
-            }
-            ;
+        if (target.getCount() < amount) {
+            throw new IllegalArgumentException();
+        }
+
+        Item newItem = target.updateCount(target.getCount() - amount);
+        if (newItem.getCount() == 0) {
+            // Remove from order if amount is 0
+            items.remove(target);
+        } else {
+            // Else, just adjust count
+            items.setItem(target, newItem);
         }
     }
 

--- a/src/main/java/seedu/address/model/order/Order.java
+++ b/src/main/java/seedu/address/model/order/Order.java
@@ -8,6 +8,10 @@ import javafx.collections.ObservableList;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.UniqueItemList;
 
+/**
+ * Wraps all data at the order level
+ * Duplicates are aggregated by adjusting count (by .isSameItem comparison)
+ */
 public class Order {
     private final UniqueItemList items;
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -104,6 +104,7 @@ public class AddCommandIntegrationTest {
     public void execute_newItemNoName_incompleteInfofailure() {
         ItemDescriptor validDescriptor = new ItemDescriptorBuilder()
                 .withName(VALID_NAME_BAGEL)
+                .withCount(1)
                 .build();
 
         AddCommand addCommand = new AddCommand(validDescriptor);

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -80,6 +80,7 @@ public class AddCommandTest {
     public void execute_newItemNoName_incompleteInfofailure() {
         ItemDescriptor validDescriptor = new ItemDescriptorBuilder()
                 .withName(VALID_NAME_BAGEL)
+                .withCount(1)
                 .build();
 
         AddCommand addCommand = new AddCommand(validDescriptor);

--- a/src/test/java/seedu/address/logic/commands/EndAndTransactOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EndAndTransactOrderCommandTest.java
@@ -127,9 +127,9 @@ public class EndAndTransactOrderCommandTest {
         }
 
         @Override
-        public void removeFromOrder(Item item) {
+        public void removeFromOrder(Item item, int amount) {
             assert hasUnclosedOrder();
-            optionalOrder.get().removeItem(item);
+            optionalOrder.get().removeItem(item, amount);
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/RemoveFromOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemoveFromOrderCommandTest.java
@@ -1,21 +1,40 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
-
-import java.util.HashSet;
-import java.util.Optional;
+import static seedu.address.testutil.TypicalItems.BAGEL;
+import static seedu.address.testutil.TypicalItems.DONUT;
+import static seedu.address.testutil.TypicalItems.getTypicalInventory;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.util.StringUtil;
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.ModelStub;
-import seedu.address.model.item.Item;
-import seedu.address.model.item.Name;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.order.Order;
+import seedu.address.testutil.ItemDescriptorBuilder;
 
 public class RemoveFromOrderCommandTest {
+
+    private Model modelWithoutOrder = new ModelManager(getTypicalInventory(), new UserPrefs());
+    private Model modelWithOrder = getModelWithOrderedDonut();
+
+    /**
+     * Returns a model with 5 donuts in its unclosed order
+     */
+    private Model getModelWithOrderedDonut() {
+        Model model = new ModelManager(getTypicalInventory(), new UserPrefs());
+        model.addItem(DONUT.updateCount(5));
+        model.setOrder(new Order());
+        model.addToOrder(DONUT.updateCount(5));
+
+        return model;
+    }
 
     @Test
     public void constructor_nullItem_throwsNullPointerException() {
@@ -23,97 +42,135 @@ public class RemoveFromOrderCommandTest {
     }
 
     @Test
-    public void execute_normalRemoval_itemRemoved() throws CommandException {
-        ModelStubWithOrder modelStub = new ModelStubWithOrder();
-        modelStub.setOrder(new Order());
-        Item toRemove = new Item(new Name("milk"), 120123, 10, new HashSet<>(), 1.1, 2.2);
-        modelStub.addToOrder(toRemove);
-        Order expectedOrder = new Order();
+    public void execute_modelHasNoUnclosedOrder_giveNoUnclosedOrderMessage() {
+        ItemDescriptor toAddDescriptor = new ItemDescriptor(DONUT);
 
-        RemoveFromOrderCommand command = new RemoveFromOrderCommand(toRemove);
-        command.execute(modelStub);
+        AddToOrderCommand command = new AddToOrderCommand(toAddDescriptor);
 
-        assertEquals(expectedOrder, modelStub.optionalOrder.get());
+        assertCommandFailure(command, modelWithoutOrder, AddToOrderCommand.MESSAGE_NO_UNCLOSED_ORDER);
     }
 
     @Test
-    public void execute_removeWithOnlyNameMatch_itemRemoved() throws CommandException {
-        ModelStubWithOrder modelStub = new ModelStubWithOrder();
-        modelStub.setOrder(new Order());
-        Item item = new Item(new Name("milk"), 120123, 10, new HashSet<>(), 1.1, 2.2);
-        Item toRemove = new Item(new Name("milk"), 431521, 12, new HashSet<>(), 1.1, 2.2);
-        modelStub.addToOrder(item);
-        Order expectedOrder = new Order();
+    public void execute_nameInOrderRemoveSome_itemCountDecreasedInOrder() {
+        ItemDescriptor toRemoveDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_DONUT)
+                .withCount(1)
+                .build();
+        RemoveFromOrderCommand command = new RemoveFromOrderCommand(toRemoveDescriptor);
+        CommandResult expectedResult = new CommandResult(
+                String.format(RemoveFromOrderCommand.MESSAGE_SUCCESS, 1, VALID_NAME_DONUT));
 
-        RemoveFromOrderCommand command = new RemoveFromOrderCommand(toRemove);
-        command.execute(modelStub);
+        Model expectedModel = getModelWithOrderedDonut();
+        expectedModel.removeFromOrder(DONUT, 1);
 
-        assertEquals(expectedOrder, modelStub.optionalOrder.get());
+        assertCommandSuccess(command, modelWithOrder, expectedResult, expectedModel);
     }
 
     @Test
-    public void execute_removeWithOnlyIdMatch_itemRemoved() throws CommandException {
-        ModelStubWithOrder modelStub = new ModelStubWithOrder();
-        modelStub.setOrder(new Order());
-        Item item = new Item(new Name("milk"), 120123, 10, new HashSet<>(), 1.1, 2.2);
-        Item toRemove = new Item(new Name(StringUtil.generateRandomString()),
-                120123, 12, new HashSet<>(), 1.1, 2.2);
-        modelStub.addToOrder(item);
-        Order expectedOrder = new Order();
+    public void execute_idInInventoryRemoveSome_itemCountDecreasedInOrder() {
+        ItemDescriptor toRemoveDescriptor = new ItemDescriptorBuilder()
+                .withId(VALID_ID_DONUT)
+                .withCount(1)
+                .build();
+        RemoveFromOrderCommand command = new RemoveFromOrderCommand(toRemoveDescriptor);
+        CommandResult expectedResult = new CommandResult(
+                String.format(RemoveFromOrderCommand.MESSAGE_SUCCESS, 1, VALID_NAME_DONUT));
 
-        RemoveFromOrderCommand command = new RemoveFromOrderCommand(toRemove);
-        command.execute(modelStub);
+        Model expectedModel = getModelWithOrderedDonut();
+        expectedModel.removeFromOrder(DONUT, 1);
 
-        assertEquals(expectedOrder, modelStub.optionalOrder.get());
+        assertCommandSuccess(command, modelWithOrder, expectedResult, expectedModel);
     }
 
     @Test
-    public void execute_removeNonExistentialItem_orderUnchanged() throws CommandException {
-        ModelStubWithOrder modelStub = new ModelStubWithOrder();
-        modelStub.setOrder(new Order());
-        Item item = new Item(new Name("milk"), 120125, 10, new HashSet<>(), 1.1, 2.2);
-        Item toRemove = new Item(new Name("banana"), 120123, 10, new HashSet<>(), 1.1, 2.2);
-        modelStub.addToOrder(item);
-        Order expectedOrder = new Order();
-        expectedOrder.addItem(item);
+    public void execute_nameAndIdInInventoryRemoveSome_itemCountDecreasedInOrder() {
+        ItemDescriptor toRemoveDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_DONUT)
+                .withId(VALID_ID_DONUT)
+                .withCount(1)
+                .build();
+        RemoveFromOrderCommand command = new RemoveFromOrderCommand(toRemoveDescriptor);
+        CommandResult expectedResult = new CommandResult(
+                String.format(RemoveFromOrderCommand.MESSAGE_SUCCESS, 1, VALID_NAME_DONUT));
 
-        RemoveFromOrderCommand command = new RemoveFromOrderCommand(toRemove);
-        command.execute(modelStub);
+        Model expectedModel = getModelWithOrderedDonut();
+        expectedModel.removeFromOrder(DONUT, 1);
 
-        assertEquals(expectedOrder, modelStub.optionalOrder.get());
+        assertCommandSuccess(command, modelWithOrder, expectedResult, expectedModel);
     }
 
-    /**
-     * A model stub that has only order related functionality.
-     */
-    private class ModelStubWithOrder extends ModelStub {
-        private Optional<Order> optionalOrder;
+    @Test
+    public void execute_nameInOrderRemoveAll_itemRemoved() {
+        ItemDescriptor toRemoveDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_DONUT)
+                .withCount(DONUT.getCount())
+                .build();
+        RemoveFromOrderCommand command = new RemoveFromOrderCommand(toRemoveDescriptor);
+        CommandResult expectedResult = new CommandResult(
+                String.format(RemoveFromOrderCommand.MESSAGE_SUCCESS, DONUT.getCount(), VALID_NAME_DONUT));
 
-        ModelStubWithOrder() {
-            optionalOrder = Optional.empty();
-        }
+        Model expectedModel = getModelWithOrderedDonut();
+        expectedModel.removeFromOrder(DONUT, DONUT.getCount());
 
-        @Override
-        public void setOrder(Order order) {
-            RemoveFromOrderCommandTest.ModelStubWithOrder.this.optionalOrder = Optional.of(order);
-        }
-
-        @Override
-        public boolean hasUnclosedOrder() {
-            return optionalOrder.isPresent();
-        }
-
-        @Override
-        public void addToOrder(Item item) {
-            assert hasUnclosedOrder();
-            optionalOrder.get().addItem(item);
-        }
-
-        @Override
-        public void removeFromOrder(Item item) {
-            assert hasUnclosedOrder();
-            optionalOrder.get().removeItem(item);
-        }
-
+        assertCommandSuccess(command, modelWithOrder, expectedResult, expectedModel);
     }
+
+    @Test
+    public void execute_idInInventoryRemoveAll_itemRemoved() {
+        ItemDescriptor toRemoveDescriptor = new ItemDescriptorBuilder()
+                .withId(VALID_ID_DONUT)
+                .withCount(DONUT.getCount())
+                .build();
+        RemoveFromOrderCommand command = new RemoveFromOrderCommand(toRemoveDescriptor);
+        CommandResult expectedResult = new CommandResult(
+                String.format(RemoveFromOrderCommand.MESSAGE_SUCCESS, DONUT.getCount(), VALID_NAME_DONUT));
+
+        Model expectedModel = getModelWithOrderedDonut();
+        expectedModel.removeFromOrder(DONUT, DONUT.getCount());
+
+        assertCommandSuccess(command, modelWithOrder, expectedResult, expectedModel);
+    }
+
+    @Test
+    public void execute_nameAndIdInInventoryRemoveAll_itemRemoved() {
+        ItemDescriptor toRemoveDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_DONUT)
+                .withId(VALID_ID_DONUT)
+                .withCount(DONUT.getCount())
+                .build();
+        RemoveFromOrderCommand command = new RemoveFromOrderCommand(toRemoveDescriptor);
+        CommandResult expectedResult = new CommandResult(
+                String.format(RemoveFromOrderCommand.MESSAGE_SUCCESS, DONUT.getCount(), VALID_NAME_DONUT));
+
+        Model expectedModel = getModelWithOrderedDonut();
+        expectedModel.removeFromOrder(DONUT, DONUT.getCount());
+
+        assertCommandSuccess(command, modelWithOrder, expectedResult, expectedModel);
+    }
+
+    @Test
+    public void execute_itemNotInOrder_throwCommandException() {
+        ItemDescriptor toRemoveDescriptor = new ItemDescriptor(BAGEL);
+        RemoveFromOrderCommand command = new RemoveFromOrderCommand(toRemoveDescriptor);
+
+        String expectedMessage = RemoveFromOrderCommand.MESSAGE_ITEM_NOT_FOUND;
+
+        assertCommandFailure(command, modelWithOrder, expectedMessage);
+    }
+
+    @Test
+    public void execute_multipleMatchesInOrder_throwCommandException() {
+        modelWithOrder.addToOrder(BAGEL);
+        ItemDescriptor toRemoveDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_DONUT)
+                .withId(VALID_ID_BAGEL)
+                .withCount(1)
+                .build();
+
+        RemoveFromOrderCommand command = new RemoveFromOrderCommand(toRemoveDescriptor);
+
+        assertCommandFailure(command, modelWithOrder, RemoveFromOrderCommand.MESSAGE_MULTIPLE_MATCHES);
+    }
+
+
 }

--- a/src/test/java/seedu/address/logic/commands/RemoveFromOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemoveFromOrderCommandTest.java
@@ -159,6 +159,18 @@ public class RemoveFromOrderCommandTest {
     }
 
     @Test
+    public void execute_overRemoveItem_throwCommandException() {
+        ItemDescriptor toRemoveDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_DONUT)
+                .withCount(BAGEL.getCount() + 1)
+                .build();
+
+        RemoveFromOrderCommand command = new RemoveFromOrderCommand(toRemoveDescriptor);
+
+        assertCommandFailure(command, modelWithOrder, RemoveFromOrderCommand.MESSAGE_INSUFFICIENT_ITEM);
+    }
+
+    @Test
     public void execute_multipleMatchesInOrder_throwCommandException() {
         modelWithOrder.addToOrder(BAGEL);
         ItemDescriptor toRemoveDescriptor = new ItemDescriptorBuilder()

--- a/src/test/java/seedu/address/logic/parser/AddToOrderCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddToOrderCommandParserTest.java
@@ -1,0 +1,127 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_ZERO;
+import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_COUNT_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_COUNT_VALUE;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ID_BAGEL_2;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_BAKED;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_POPULAR;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNT_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.AddToOrderCommand;
+import seedu.address.model.item.ItemDescriptor;
+import seedu.address.model.item.Name;
+import seedu.address.testutil.ItemDescriptorBuilder;
+
+public class AddToOrderCommandParserTest {
+    private AddToOrderCommandParser parser = new AddToOrderCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .withId(VALID_ID_BAGEL)
+                .withCount(VALID_COUNT_BAGEL)
+                .build();
+
+        // All fields
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL,
+                new AddToOrderCommand(expectedDescriptor));
+
+        // multiple id - last id accepted
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_DONUT + ID_DESC_BAGEL + COUNT_DESC_BAGEL
+                , new AddToOrderCommand(expectedDescriptor));
+
+        // multiple count - last count accepted
+        assertParseSuccess(parser,
+                VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_DONUT + COUNT_DESC_BAGEL,
+                new AddToOrderCommand(expectedDescriptor));
+    }
+
+    @Test
+    public void parse_nameOnlyNoId_success() {
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .withCount(VALID_COUNT_BAGEL)
+                .build();
+
+        assertParseSuccess(parser, VALID_NAME_BAGEL + COUNT_DESC_BAGEL,
+                new AddToOrderCommand(expectedDescriptor));
+    }
+
+    @Test
+    public void parse_idOnlyNoName_success() {
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withId(VALID_ID_BAGEL)
+                .withCount(VALID_COUNT_BAGEL)
+                .build();
+
+        assertParseSuccess(parser, ID_DESC_BAGEL + COUNT_DESC_BAGEL,
+                new AddToOrderCommand(expectedDescriptor));
+    }
+
+    @Test
+    public void parse_countMissing_success() {
+
+        // no count (count should be defaulted to 1)
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .withId(VALID_ID_BAGEL)
+                .withCount(1)
+                .build();
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL,
+                new AddToOrderCommand(expectedDescriptor));
+
+    }
+
+    @Test
+    public void parse_noNameOrId_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddToOrderCommand.MESSAGE_USAGE);
+
+        // both name and id prefix missing
+        assertParseFailure(parser, COUNT_DESC_BAGEL, expectedMessage);
+    }
+
+    @Test
+    public void parse_countZero_failure() {
+        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_ZERO,
+                Messages.MESSAGE_INVALID_COUNT_INTEGER);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, INVALID_NAME + ID_DESC_BAGEL + COUNT_DESC_BAGEL
+                + TAG_DESC_POPULAR + TAG_DESC_BAKED, Name.MESSAGE_CONSTRAINTS);
+
+        // invalid id with negative number
+        assertParseFailure(parser, VALID_NAME_BAGEL + INVALID_ID_BAGEL_2 + COUNT_DESC_BAGEL
+                + TAG_DESC_POPULAR + TAG_DESC_BAKED, Messages.MESSAGE_INVALID_ID_LENGTH_AND_SIGN);
+
+        // invalid id with 3 numbers
+        assertParseFailure(parser, VALID_NAME_BAGEL + INVALID_ID_BAGEL + COUNT_DESC_BAGEL
+                + TAG_DESC_POPULAR + TAG_DESC_BAKED, Messages.MESSAGE_INVALID_ID_LENGTH_AND_SIGN);
+
+        // invalid count format
+        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + INVALID_COUNT_FORMAT + TAG_DESC_BAKED,
+                Messages.MESSAGE_INVALID_COUNT_FORMAT);
+
+        // invalid count value
+        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + INVALID_COUNT_VALUE + TAG_DESC_BAKED,
+                Messages.MESSAGE_INVALID_COUNT_INTEGER);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddToOrderCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddToOrderCommandParserTest.java
@@ -43,8 +43,9 @@ public class AddToOrderCommandParserTest {
                 new AddToOrderCommand(expectedDescriptor));
 
         // multiple id - last id accepted
-        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_DONUT + ID_DESC_BAGEL + COUNT_DESC_BAGEL
-                , new AddToOrderCommand(expectedDescriptor));
+        assertParseSuccess(parser,
+                VALID_NAME_BAGEL + ID_DESC_DONUT + ID_DESC_BAGEL + COUNT_DESC_BAGEL,
+                new AddToOrderCommand(expectedDescriptor));
 
         // multiple count - last count accepted
         assertParseSuccess(parser,

--- a/src/test/java/seedu/address/logic/parser/RemoveFromOrderCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RemoveFromOrderCommandParserTest.java
@@ -1,0 +1,124 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_ZERO;
+import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_COUNT_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_COUNT_VALUE;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ID_BAGEL_2;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNT_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.RemoveFromOrderCommand;
+import seedu.address.model.item.ItemDescriptor;
+import seedu.address.model.item.Name;
+import seedu.address.testutil.ItemDescriptorBuilder;
+
+public class RemoveFromOrderCommandParserTest {
+    private RemoveFromOrderCommandParser parser = new RemoveFromOrderCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .withId(VALID_ID_BAGEL)
+                .withCount(VALID_COUNT_BAGEL)
+                .build();
+
+        // All fields
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL,
+                new RemoveFromOrderCommand(expectedDescriptor));
+
+        // multiple id - last id accepted
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_DONUT + ID_DESC_BAGEL + COUNT_DESC_BAGEL,
+                new RemoveFromOrderCommand(expectedDescriptor));
+
+        // multiple count - last count accepted
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_DONUT + COUNT_DESC_BAGEL,
+                new RemoveFromOrderCommand(expectedDescriptor));
+    }
+
+    @Test
+    public void parse_nameOnlyNoId_success() {
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .withCount(VALID_COUNT_BAGEL)
+                .build();
+
+        assertParseSuccess(parser, VALID_NAME_BAGEL + COUNT_DESC_BAGEL,
+                new RemoveFromOrderCommand(expectedDescriptor));
+    }
+
+    @Test
+    public void parse_idOnlyNoName_success() {
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withId(VALID_ID_BAGEL)
+                .withCount(VALID_COUNT_BAGEL)
+                .build();
+
+        assertParseSuccess(parser, ID_DESC_BAGEL + COUNT_DESC_BAGEL,
+                new RemoveFromOrderCommand(expectedDescriptor));
+    }
+
+    @Test
+    public void parse_countMissing_success() {
+
+        // no count (count should be defaulted to 1)
+        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL)
+                .withId(VALID_ID_BAGEL)
+                .withCount(1)
+                .build();
+        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL,
+                new RemoveFromOrderCommand(expectedDescriptor));
+
+    }
+
+    @Test
+    public void parse_noNameOrId_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveFromOrderCommand.MESSAGE_USAGE);
+
+        // both name and id prefix missing
+        assertParseFailure(parser, COUNT_DESC_BAGEL, expectedMessage);
+    }
+
+    @Test
+    public void parse_countZero_failure() {
+        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_ZERO,
+                Messages.MESSAGE_INVALID_COUNT_INTEGER);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, INVALID_NAME + ID_DESC_BAGEL + COUNT_DESC_BAGEL,
+                Name.MESSAGE_CONSTRAINTS);
+
+        // invalid id with negative number
+        assertParseFailure(parser, VALID_NAME_BAGEL + INVALID_ID_BAGEL_2 + COUNT_DESC_BAGEL,
+                Messages.MESSAGE_INVALID_ID_LENGTH_AND_SIGN);
+
+        // invalid id with 3 numbers
+        assertParseFailure(parser, VALID_NAME_BAGEL + INVALID_ID_BAGEL + COUNT_DESC_BAGEL,
+                Messages.MESSAGE_INVALID_ID_LENGTH_AND_SIGN);
+
+        // invalid count format
+        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + INVALID_COUNT_FORMAT,
+                Messages.MESSAGE_INVALID_COUNT_FORMAT);
+
+        // invalid count value
+        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + INVALID_COUNT_VALUE,
+                Messages.MESSAGE_INVALID_COUNT_INTEGER);
+    }
+}

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -213,69 +213,6 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void addToOrder_nullItem_throwNullPointerException() {
-        assertThrows(NullPointerException.class, () -> modelManager.addToOrder(null));
-    }
-
-    @Test
-    public void addToOrder_noOrderIsSetYet_throwAssertionError() {
-        ModelManager model = new ModelManager();
-        assertThrows(AssertionError.class, () -> model.addToOrder(APPLE_PIE));
-    }
-
-    @Test
-    public void addToOrder_normalItem_itemAdded() {
-        modelManager.setOrder(new Order());
-        Order expectedOrder = new Order();
-        modelManager.addToOrder(APPLE_PIE);
-        expectedOrder.addItem(APPLE_PIE);
-
-        assertEquals(modelManager.getOrder(), expectedOrder);
-    }
-
-    /*
-    @Test
-    public void addToOrder_duplicateItem_itemCountIncrease() {
-        // TODO: Implement duplicate item count increasing!
-        modelManager.setOrder(TypicalOrders.getTypicalOrder());
-        Order expectedOrder = TypicalOrders.getTypicalOrder();
-        modelManager.addToOrder(APPLE_PIE);
-        expectedOrder.addItem(APPLE_PIE);
-
-        assertEquals(modelManager.getOrder(), expectedOrder);
-    }*/
-
-    @Test
-    public void removeFromOrder_nullItem_throwNullPointerException() {
-        assertThrows(NullPointerException.class, () -> modelManager.removeFromOrder(null));
-    }
-
-    @Test
-    public void removeFromOrder_noOrderIsSetYet_throwAssertionError() {
-        ModelManager model = new ModelManager();
-        assertThrows(AssertionError.class, () -> model.removeFromOrder(APPLE_PIE));
-    }
-
-    @Test
-    public void removeFromOrder_normalItem_itemRemoved() {
-        modelManager.setOrder(TypicalOrders.getTypicalOrder());
-        Order expectedOrder = TypicalOrders.getTypicalOrder();
-        modelManager.removeFromOrder(APPLE_PIE);
-        expectedOrder.removeItem(APPLE_PIE);
-
-        assertEquals(modelManager.getOrder(), expectedOrder);
-    }
-
-    @Test
-    public void removeFromOrder_nonExistingItem_orderNotChanged() {
-        modelManager.setOrder(TypicalOrders.getTypicalOrder());
-        Order expectedOrder = TypicalOrders.getTypicalOrder();
-        modelManager.removeFromOrder(TypicalItems.getRandomItem());
-
-        assertEquals(modelManager.getOrder(), expectedOrder);
-    }
-
-    @Test
     public void transactAndClearOrder_noOrderIsSetYet_throwAssertionError() {
         ModelManager model = new ModelManager();
         assertThrows(AssertionError.class, model::transactAndClearOrder);

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -122,7 +122,12 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public void removeFromOrder(Item item) {
+    public List<Item> getFromOrder(ItemDescriptor itemDescriptor) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void removeFromOrder(Item item, int amount) {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/model/OrderTest.java
+++ b/src/test/java/seedu/address/model/OrderTest.java
@@ -2,7 +2,12 @@ package seedu.address.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_DONUT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.testutil.TypicalItems.APPLE_PIE;
+import static seedu.address.testutil.TypicalItems.BAGEL;
+import static seedu.address.testutil.TypicalItems.DONUT;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,7 +15,9 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemDescriptor;
 import seedu.address.model.order.Order;
+import seedu.address.testutil.ItemDescriptorBuilder;
 import seedu.address.testutil.TypicalItems;
 import seedu.address.testutil.TypicalOrders;
 
@@ -96,6 +103,52 @@ class OrderTest {
         Order expectedOrder = new Order();
 
         assertEquals(order, expectedOrder);
+    }
+
+    @Test
+    public void getItem_itemInInventory_returnsItem() {
+        order.addItem(BAGEL);
+
+        // Search by name
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
+        assertEquals(order.getItems(descriptor), List.of(BAGEL));
+
+        // Search by id
+        descriptor = new ItemDescriptorBuilder().withId(VALID_ID_BAGEL).build();
+        assertEquals(order.getItems(descriptor), List.of(BAGEL));
+
+        // Search by name and id
+        descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
+        assertEquals(order.getItems(descriptor), List.of(BAGEL));
+    }
+
+    @Test
+    public void getItem_itemNotInInventory_returnEmptyList() {
+        order.addItem(DONUT);
+
+        // Search by name
+        ItemDescriptor descriptor = new ItemDescriptorBuilder().withName(VALID_NAME_BAGEL).build();
+        assertEquals(order.getItems(descriptor), List.of());
+
+        // Search by id
+        descriptor = new ItemDescriptorBuilder().withId(VALID_ID_BAGEL).build();
+        assertEquals(order.getItems(descriptor), List.of());
+
+        // Search by name and id
+        descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_BAGEL).build();
+        assertEquals(order.getItems(descriptor), List.of());
+    }
+
+    @Test
+    public void getItem_multipleMatches_returnMultiple() {
+        order.addItem(DONUT);
+        order.addItem(BAGEL);
+
+        ItemDescriptor descriptor = new ItemDescriptorBuilder()
+                .withName(VALID_NAME_BAGEL).withId(VALID_ID_DONUT).build();
+        assertEquals(order.getItems(descriptor), List.of(DONUT, BAGEL));
     }
 
 }

--- a/src/test/java/seedu/address/model/OrderTest.java
+++ b/src/test/java/seedu/address/model/OrderTest.java
@@ -9,14 +9,14 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.model.item.Item;
 import seedu.address.model.order.Order;
-import seedu.address.testutil.ItemBuilder;
 import seedu.address.testutil.TypicalItems;
 import seedu.address.testutil.TypicalOrders;
 
 class OrderTest {
+
+    private Order order = new Order();
 
     @Test
     public void constructor_emptyConstructor_emptyOrderCreated() {
@@ -46,59 +46,56 @@ class OrderTest {
     }
 
     @Test
-    public void addItem_normalItem_itemAdded() {
+    public void addItem_newItem_itemAdded() {
         Order order = new Order();
         order.addItem(APPLE_PIE);
+
         assertEquals(order.getOrderItems(), List.of(APPLE_PIE));
+    }
+
+    @Test
+    public void addItem_ExistingItem_itemCountIncreased() {
+        Order order = new Order();
+        order.addItem(APPLE_PIE.updateCount(1));
+        order.addItem(APPLE_PIE.updateCount(2));
+
+        assertEquals(order.getOrderItems(), List.of(APPLE_PIE.updateCount(3)));
     }
 
     @Test
     public void removeItem_nullItem_throwNullPointerException() {
         Order order = new Order();
-        assertThrows(NullPointerException.class, () -> order.removeItem(null));
+        assertThrows(NullPointerException.class, () -> order.removeItem(null, 0));
     }
 
     @Test
-    public void removeItem_normalItem_itemRemoved() {
-        Order order = TypicalOrders.getTypicalOrder();
-        List<Item> expectedItems = TypicalItems.getTypicalItems();
-        order.removeItem(APPLE_PIE);
-        expectedItems.remove(APPLE_PIE);
-
-        assertEquals(order.getOrderItems(), expectedItems);
+    public void removeItem_negativeCount_throwAssertionError() {
+        Order order = new Order();
+        assertThrows(AssertionError.class, () -> order.removeItem(APPLE_PIE, -1));
     }
 
     @Test
-    public void removeItem_onlyNameMatches_itemRemoved() {
-        Order order = TypicalOrders.getTypicalOrder();
-        List<Item> expectedItems = TypicalItems.getTypicalItems();
-        expectedItems.remove(APPLE_PIE);
+    public void removeItem_someExistingItem_itemCountDecreased() {
 
-        Item applePieWithOnlyName = new ItemBuilder()
-                .withName("Apple Pie")
-                .withId("416386")
-                .withCount("5")
-                .withTags("baked").build();
+        order.addItem(APPLE_PIE);
+        order.removeItem(APPLE_PIE, 2);
 
-        order.removeItem(applePieWithOnlyName);
+        Order expectedOrder = new Order();
+        Item expectedPie = APPLE_PIE.updateCount(APPLE_PIE.getCount() - 2);
+        expectedOrder.addItem(expectedPie);
 
-        assertEquals(order.getOrderItems(), expectedItems);
+        assertEquals(order, expectedOrder);
     }
 
     @Test
-    public void removeItem_onlyIdMatches_itemRemoved() {
-        Order order = TypicalOrders.getTypicalOrder();
-        List<Item> expectedItems = TypicalItems.getTypicalItems();
-        expectedItems.remove(APPLE_PIE);
+    public void removeItem_allExistingItem_itemRemoved() {
 
-        Item applePieWithOnlyId = new ItemBuilder()
-                .withName(StringUtil.generateRandomString())
-                .withId("222222")
-                .withCount("5")
-                .withTags("baked").build();
+        order.addItem(APPLE_PIE);
+        order.removeItem(APPLE_PIE, APPLE_PIE.getCount());
 
-        order.removeItem(applePieWithOnlyId);
+        Order expectedOrder = new Order();
 
-        assertEquals(order.getOrderItems(), expectedItems);
+        assertEquals(order, expectedOrder);
     }
+
 }

--- a/src/test/java/seedu/address/model/OrderTest.java
+++ b/src/test/java/seedu/address/model/OrderTest.java
@@ -54,7 +54,7 @@ class OrderTest {
     }
 
     @Test
-    public void addItem_ExistingItem_itemCountIncreased() {
+    public void addItem_existingItem_itemCountIncreased() {
         Order order = new Order();
         order.addItem(APPLE_PIE.updateCount(1));
         order.addItem(APPLE_PIE.updateCount(2));


### PR DESCRIPTION
Fixes #75.

Adding to order and removing from order lacks several key functionalities.

Let's make these actions more robust. This PR enhances the following actions:

1. Adding to order
    - Checks whether item is in inventory before adding
    - If details specified matches multiple items, notify the user
    - If item added already exists in order, increment its count
    
2. Removing from order
    - Allows partial removal (decrement count instead of removing item entirely)
    - Checks whether item is in order before removing
    - If removing more than amount in order, notify the user
    - If details specified matches multiple items, notify the user

The PR also does the following:
- Build on parser tests
- Standardise order command formats with `AddCommand` and `RemoveCommand`