### PR TITLE
Enhance parsing

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -86,36 +86,37 @@ public class MainApp extends Application {
      * or an empty address book will be used instead if errors occur when reading {@code storage}'s address book.
      */
     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
-        Optional<ReadOnlyInventory> addressBookOptional;
+        Optional<ReadOnlyInventory> inventoryOptional;
         ReadOnlyInventory initialData;
         Optional<ReadOnlyTransactionList> transactionListOptional;
         ReadOnlyTransactionList transactionList;
         Optional<ReadOnlyBookKeeping> bookKeepingOptional;
         ReadOnlyBookKeeping bookKeeping;
         try {
-            addressBookOptional = storage.readInventory();
+            inventoryOptional = storage.readInventory();
             transactionListOptional = storage.readTransactionList();
             bookKeepingOptional = storage.readBookKeeping();
-            if (!addressBookOptional.isPresent()) {
+            if (inventoryOptional.isEmpty()) {
                 logger.info("Data file not found. Will be starting with a sample AddressBook");
             }
-            if (!transactionListOptional.isPresent()) {
+            if (transactionListOptional.isEmpty()) {
                 logger.info("Transaction not found");
             }
-            if (!bookKeepingOptional.isPresent()) {
+            if (bookKeepingOptional.isEmpty()) {
                 logger.info("BookKeeping not found");
             }
-            initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleInventory);
+            initialData = inventoryOptional.orElseGet(SampleDataUtil::getSampleInventory);
             transactionList = transactionListOptional
                     .orElseGet(() -> new TransactionList(new ArrayList<TransactionRecord>()));
-            bookKeeping = bookKeepingOptional.orElseGet(() -> new BookKeeping());
+            bookKeeping = bookKeepingOptional.orElseGet(BookKeeping::new);
+
         } catch (DataConversionException e) {
-            logger.warning("Data file not in the correct format. Will be starting with an empty AddressBook");
+            logger.warning("Data file not in the correct format. Will be starting with an empty inventory");
             initialData = new Inventory();
             transactionList = new TransactionList();
             bookKeeping = new BookKeeping();
         } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
+            logger.warning("Problem while reading from the file. Will be starting with an empty inventory");
             initialData = new Inventory();
             transactionList = new TransactionList();
             bookKeeping = new BookKeeping();
@@ -182,7 +183,7 @@ public class MainApp extends Application {
                     + "Using default user prefs");
             initializedPrefs = new UserPrefs();
         } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
+            logger.warning("Problem while reading from the file. Will be starting with an empty inventory");
             initializedPrefs = new UserPrefs();
         }
 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -11,8 +11,11 @@ public class Messages {
     public static final String MESSAGE_ITEMS_LISTED_OVERVIEW = "%1$d items listed!";
     public static final String MESSAGE_INVALID_COUNT_INTEGER = "The count provided must be positive!";
     public static final String MESSAGE_INVALID_COUNT_FORMAT = "The count provided must be integer!";
-    public static final String MESSAGE_INVALID_SALESPRICE_FORMAT = "The sales price provided must be positive integer!";
-    public static final String MESSAGE_INVALID_COSTPRICE_FORMAT = "The cost price provided must be positive integer!";
+
+    public static final String MESSAGE_INVALID_PRICE_FORMAT = "Prices provided must be numerical values!";
+    public static final String MESSAGE_INVALID_PRICE_RANGE =
+            "Prices provided must be at least $0 and less than $10,000,000!";
+
     public static final String MESSAGE_INVALID_ID_FORMAT = "The id provided must be integer!";
     public static final String MESSAGE_INVALID_ID_LENGTH_AND_SIGN = "The id provided must be positive"
             + " and at most 6 digits!";

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -7,6 +7,8 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  * Helper functions for handling strings.
@@ -15,29 +17,33 @@ public class StringUtil {
     private static final long DEFAULT_RANDOM_SEED = 10L;
 
     /**
-     * Returns true if the {@code sentence} contains the {@code word}.
-     *   Ignores case, but a full word match is required.
+     * Returns true if any of the phrases in {@code sentence} starts with the {@code query}.
+     * Ignores case.
      *   <br>examples:<pre>
      *       containsWordIgnoreCase("ABc def", "abc") == true
-     *       containsWordIgnoreCase("ABc def", "DEF") == true
-     *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
+     *       containsWordIgnoreCase("ABc def", "DE") == true
+     *       containsWordIgnoreCase("ABc def", "def ghi") == false
      *       </pre>
      * @param sentence cannot be null
-     * @param word cannot be null, cannot be empty, must be a single word
+     * @param query cannot be null
      */
-    public static boolean containsWordIgnoreCase(String sentence, String word) {
+    public static boolean phrasesStartsWithQuery(String sentence, String query) {
         requireNonNull(sentence);
-        requireNonNull(word);
+        requireNonNull(query);
 
-        String preppedWord = word.trim();
-        checkArgument(!preppedWord.isEmpty(), "Word parameter cannot be empty");
-        //checkArgument(preppedWord.split("\\s+").length == 1, "Word parameter should be a single word");
+        String preppedQuery = query.trim().toLowerCase();
+        checkArgument(!preppedQuery.isEmpty(), "query parameter cannot be empty");
 
-        String preppedSentence = sentence;
-        String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
+        String preppedSentence = sentence.toLowerCase();
+        // Indexes of start of each word in the sentence
+        IntStream phrasesIndexes = IntStream.range(0, sentence.length() - 1).filter(
+                x -> sentence.charAt(x) != ' '
+                        && (x == 0 || sentence.charAt(x - 1) == ' ')
+        );
 
-        return Arrays.stream(wordsInPreppedSentence)
-                .anyMatch(preppedWord::equalsIgnoreCase);
+        // True if any phrase starts with the query
+        return phrasesIndexes
+                .anyMatch(i -> preppedSentence.startsWith(preppedQuery, i));
     }
 
     /**

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -5,16 +5,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.Arrays;
 import java.util.Random;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 /**
  * Helper functions for handling strings.
  */
 public class StringUtil {
-    private static final long DEFAULT_RANDOM_SEED = 10L;
 
     /**
      * Returns true if any of the phrases in {@code sentence} starts with the {@code query}.
@@ -37,8 +34,8 @@ public class StringUtil {
         String preppedSentence = sentence.toLowerCase();
         // Indexes of start of each word in the sentence
         IntStream phrasesIndexes = IntStream.range(0, sentence.length() - 1).filter(
-                x -> sentence.charAt(x) != ' '
-                        && (x == 0 || sentence.charAt(x - 1) == ' ')
+            x -> sentence.charAt(x) != ' '
+                 && (x == 0 || sentence.charAt(x - 1) == ' ')
         );
 
         // True if any phrase starts with the query
@@ -46,68 +43,6 @@ public class StringUtil {
                 .anyMatch(i -> preppedSentence.startsWith(preppedQuery, i));
     }
 
-    /**
-     * Returns true if the {@code sentence} contains the {@code word}.
-     *   Ignores case, but a full word match is required.
-     *   <br>examples:<pre>
-     *       containsWordIgnoreCase("ABc def", "abc def") == true
-     *       containsWordIgnoreCase("ABc def", "abc DEF") == true
-     *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
-     *       </pre>
-     * @param sentence cannot be null
-     * @param word cannot be null, cannot be empty, must be a single word
-     */
-    public static boolean containsMultipleWord(String sentence, String word) {
-        requireNonNull(sentence);
-        requireNonNull(word);
-        if (sentence.length() == 0 || word.length() == 0) {
-            return false;
-        }
-
-        String preppedWord = word.trim();
-        checkArgument(!preppedWord.isEmpty(), "Word parameter cannot be empty");
-        String[] wordsInPreppedWord = preppedWord.split("\\s+");
-        String preppedSentence = sentence;
-        String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
-
-        return StringUtil.equalArray(wordsInPreppedSentence, wordsInPreppedWord);
-    }
-    /**
-     * Checks whether first array string contains the second array string in exact order
-     * example: [aaa, bbb, ddd] contains [aaa, Bbb] but does not contain [aaa, ddd]
-     */
-    public static boolean equalArray (String [] first, String [] second) {
-        int firstLength = first.length;
-        int secondLength = second.length;
-        if (firstLength == 0 || secondLength == 0) {
-            return false;
-        }
-        boolean doesMatch = false;
-        for (int i = 0; i < firstLength - secondLength + 1; i = i + 1) {
-            doesMatch = doesMatch || StringUtil.equalArrayElements(first, second, i);
-        }
-        return doesMatch;
-    }
-    /**
-     * Helper Function for equalArray
-     * Checks whether first string array from firstStringIndex is the same as
-     * second array string with all elements in same order
-     */
-    public static boolean equalArrayElements (String [] first, String [] second, int firstStringIndex) {
-        if (firstStringIndex >= first.length) {
-            return false;
-        }
-        int indexOfFirst = firstStringIndex;
-        boolean doesMatch = true;
-        for (int j = 0; j < second.length; j = j + 1) {
-            if (!first[indexOfFirst].equalsIgnoreCase(second[j])) {
-                doesMatch = doesMatch && false;
-                break;
-            }
-            indexOfFirst = indexOfFirst + 1;
-        }
-        return doesMatch;
-    }
     /**
      * Returns a detailed message of the t, including the stack trace.
      */

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -6,16 +6,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.display.DisplayMode.DISPLAY_INVENTORY;
 
+import java.util.List;
+import java.util.function.Predicate;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.item.IdContainsNumberPredicate;
 import seedu.address.model.item.Item;
-import seedu.address.model.item.NameContainsKeywordsPredicate;
-import seedu.address.model.item.TagContainsKeywordsPredicate;
-
-import java.util.List;
-import java.util.function.Predicate;
 
 /**
  * Finds and lists all items in inventory whose name contains any of the argument keywords.

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -3,14 +3,19 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.display.DisplayMode.DISPLAY_INVENTORY;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.item.IdContainsNumberPredicate;
+import seedu.address.model.item.Item;
 import seedu.address.model.item.NameContainsKeywordsPredicate;
 import seedu.address.model.item.TagContainsKeywordsPredicate;
+
+import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Finds and lists all items in inventory whose name contains any of the argument keywords.
@@ -23,52 +28,28 @@ public class FindCommand extends Command {
     public static final String MESSAGE_INVENTORY_NOT_DISPLAYED =
             "Can't find outside inventory mode. Please use `list` first";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all items whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Able to find multiple names and ids with one command by putting multiple flags"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all items whose descrption matches any of "
+            + "the specified names, ids, or tags, and displays them as a list with index numbers.\n"
             + "\n Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_ID + "ID "
+            + PREFIX_TAG + "TAG "
             + "\n Example: " + COMMAND_WORD + " "
             + PREFIX_ID + "019381 or "
             + COMMAND_WORD + " " + PREFIX_NAME + "Banana "
             + PREFIX_NAME + "bread.";
 
-    private final NameContainsKeywordsPredicate namePredicate;
-    private final IdContainsNumberPredicate idPredicate;
-    private final TagContainsKeywordsPredicate tagPredicate;
+    private final List<Predicate<Item>> predicates;
 
     /**
      * Creates FindCommand in the case of query by name
      *
-     * @param namePredicate name of the item that the user is finding
+     * @param predicates list of predicates that describe the item(s) that the user is finding.
+     *                   (list cannot be empty).
      */
-    public FindCommand(NameContainsKeywordsPredicate namePredicate) {
-        this.namePredicate = namePredicate;
-        this.idPredicate = null;
-        this.tagPredicate = null;
-    }
-
-    /**
-     * Creates FindCommand in the case of query by id
-     *
-     * @param idPredicate id of the item that the user is finding
-     */
-    public FindCommand(IdContainsNumberPredicate idPredicate) {
-        this.idPredicate = idPredicate;
-        this.namePredicate = null;
-        this.tagPredicate = null;
-    }
-
-    /**
-     * Creates FindCommand in the case of query by tag
-     *
-     * @param tagPredicate tag of the item that the user is finding
-     */
-    public FindCommand(TagContainsKeywordsPredicate tagPredicate) {
-        this.idPredicate = null;
-        this.namePredicate = null;
-        this.tagPredicate = tagPredicate;
+    public FindCommand(List<Predicate<Item>> predicates) {
+        assert predicates.size() > 0;
+        this.predicates = predicates;
     }
 
     @Override
@@ -79,15 +60,10 @@ public class FindCommand extends Command {
             throw new CommandException(MESSAGE_INVENTORY_NOT_DISPLAYED);
         }
 
-        if (namePredicate != null) {
-            model.updateFilteredItemList(DISPLAY_INVENTORY, namePredicate);
-        }
-        if (idPredicate != null) {
-            model.updateFilteredItemList(DISPLAY_INVENTORY, idPredicate);
-        }
-        if (tagPredicate != null) {
-            model.updateFilteredItemList(DISPLAY_INVENTORY, tagPredicate);
-        }
+        Predicate<Item> combinedPredicate = item ->
+                predicates.stream().anyMatch(predicate -> predicate.test(item));
+
+        model.updateFilteredItemList(DISPLAY_INVENTORY, combinedPredicate);
 
         return new CommandResult(
                 String.format(Messages.MESSAGE_ITEMS_LISTED_OVERVIEW, model.getFilteredDisplayList().size()));
@@ -95,20 +71,9 @@ public class FindCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        if (idPredicate != null) {
-            return other == this // short circuit if same object
-                    || (other instanceof FindCommand // instanceof handles nulls
-                    && idPredicate.equals(((FindCommand) other).idPredicate)); // state check
-        }
-        if (namePredicate != null) {
-            return other == this // short circuit if same object
-                    || (other instanceof FindCommand // instanceof handles nulls
-                    && namePredicate.equals(((FindCommand) other).namePredicate)); // state check
-        } else {
-            return other == this // short circuit if same object
-                    || (other instanceof FindCommand // instanceof handles nulls
-                    && tagPredicate.equals(((FindCommand) other).tagPredicate));
-        }
+        return other == this // short circuit if same object
+                || (other instanceof FindCommand // instanceof handles nulls
+                && predicates.equals(((FindCommand) other).predicates)); // state check
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -25,7 +25,7 @@ public class FindCommand extends Command {
     public static final String MESSAGE_INVENTORY_NOT_DISPLAYED =
             "Can't find outside inventory mode. Please use `list` first";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all items whose descrption matches any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all items whose description matches any of "
             + "the specified names, ids, or tags, and displays them as a list with index numbers.\n"
             + "\n Parameters: "
             + PREFIX_NAME + "NAME "

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -54,11 +54,11 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
         // Parse salesPrice
         if (argMultimap.getValue(PREFIX_SALESPRICE).isPresent()) {
-            toAddDescriptor.setSalesPrice(ParserUtil.parseSalesPrice(argMultimap.getValue(PREFIX_SALESPRICE).get()));
+            toAddDescriptor.setSalesPrice(ParserUtil.parsePrice(argMultimap.getValue(PREFIX_SALESPRICE).get()));
         }
         // Parse costPrice
         if (argMultimap.getValue(PREFIX_COSTPRICE).isPresent()) {
-            toAddDescriptor.setCostPrice(ParserUtil.parseCostPrice(argMultimap.getValue(PREFIX_COSTPRICE).get()));
+            toAddDescriptor.setCostPrice(ParserUtil.parsePrice(argMultimap.getValue(PREFIX_COSTPRICE).get()));
         }
         // Parse tags
         if (argMultimap.getValue(PREFIX_TAG).isPresent()) {

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -37,12 +37,10 @@ public class EditCommandParser implements Parser<EditCommand> {
                         PREFIX_COSTPRICE, PREFIX_SALESPRICE);
 
         Index index;
-        boolean editId = true;
 
         ItemDescriptor itemDescriptor = new ItemDescriptor();
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             itemDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
-            editId = false;
         }
         if (argMultimap.getValue(PREFIX_ID).isPresent()) {
             itemDescriptor.setId(ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get()));
@@ -51,10 +49,10 @@ public class EditCommandParser implements Parser<EditCommand> {
             itemDescriptor.setCount(ParserUtil.parseCount(argMultimap.getValue(PREFIX_COUNT).get()));
         }
         if (argMultimap.getValue(PREFIX_COSTPRICE).isPresent()) {
-            itemDescriptor.setCostPrice(ParserUtil.parseCostPrice(argMultimap.getValue(PREFIX_COSTPRICE).get()));
+            itemDescriptor.setCostPrice(ParserUtil.parsePrice(argMultimap.getValue(PREFIX_COSTPRICE).get()));
         }
         if (argMultimap.getValue(PREFIX_SALESPRICE).isPresent()) {
-            itemDescriptor.setSalesPrice(ParserUtil.parseSalesPrice(argMultimap.getValue(PREFIX_SALESPRICE).get()));
+            itemDescriptor.setSalesPrice(ParserUtil.parsePrice(argMultimap.getValue(PREFIX_SALESPRICE).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(itemDescriptor::setTags);
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -5,13 +5,18 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.IdContainsNumberPredicate;
+import seedu.address.model.item.Item;
 import seedu.address.model.item.NameContainsKeywordsPredicate;
 import seedu.address.model.item.TagContainsKeywordsPredicate;
+import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -25,10 +30,7 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        boolean areIds = false;
-        List<String> id;
-        List<String> names;
-        List<String> tags;
+
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
@@ -43,27 +45,28 @@ public class FindCommandParser implements Parser<FindCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        // Parse id
-        if (!argMultimap.getValue(PREFIX_ID).isEmpty()) {
-            areIds = true;
+        List<Predicate<Item>> predicates = new ArrayList<>();
+
+        // Add name predicate if name(s) specified
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            predicates.add(
+                    new NameContainsKeywordsPredicate(argMultimap.getAllValues(PREFIX_NAME))
+            );
         }
 
-        // Parse tag
-        if (!argMultimap.getValue(PREFIX_TAG).isEmpty()) {
-            tags = argMultimap.getAllValues(PREFIX_TAG);
-            return new FindCommand((new TagContainsKeywordsPredicate(tags)));
+        // Add id predicate if id(s) specified
+        if (argMultimap.getValue(PREFIX_ID).isPresent()) {
+            Collection<Integer> queryIds = ParserUtil.parseIds(argMultimap.getAllValues(PREFIX_ID));
+            predicates.add(new IdContainsNumberPredicate(queryIds));
         }
 
-        // Initialise the list of names or id
-        if (areIds) {
-            id = argMultimap.getAllValues(PREFIX_ID);
-            for (String element : id) {
-                ParserUtil.parseId(element);
-            }
-            return new FindCommand((new IdContainsNumberPredicate(id)));
+        // Add tag predicate if tag(s) specified
+        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            Collection<Tag> queryTags = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+            predicates.add(new TagContainsKeywordsPredicate(queryTags));
         }
-        names = argMultimap.getAllValues(PREFIX_NAME);
-        return new FindCommand((new NameContainsKeywordsPredicate(names)));
+
+        return new FindCommand(predicates);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -95,19 +95,33 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code String count} into a {@code id}.
+     * Parses {@code String id} into an {@code Integer}.
      */
     public static Integer parseId(String id) throws ParseException {
+        Integer idValue;
         try {
-            Integer.parseInt(id);
+            idValue = Integer.parseInt(id);
         } catch (NumberFormatException e) {
             throw new ParseException(Messages.MESSAGE_INVALID_ID_FORMAT);
         }
-        if (id.length() <= 6 && Integer.parseInt(id) > 0) {
-            return Integer.parseInt(id);
-        } else {
+
+        if (id.length() != 6 || idValue < 0) {
             throw new ParseException(Messages.MESSAGE_INVALID_ID_LENGTH_AND_SIGN);
         }
+
+        return idValue;
+    }
+
+    /**
+     * Parses {@code Collection<String> idStrings} into a {@code Set<Integers>}.
+     */
+    public static Set<Integer> parseIds(Collection<String> idStrings) throws ParseException {
+        requireNonNull(idStrings);
+        final Set<Integer> idSet = new HashSet<>();
+        for (String idString : idStrings) {
+            idSet.add(parseId(idString));
+        }
+        return idSet;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -76,37 +76,22 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code String costPrice} into a {@code Double}.
+     * Parses {@code String price} into a {@code Double}.
      */
-    public static Double parseCostPrice(String costPrice) throws ParseException {
+    public static Double parsePrice(String price) throws ParseException {
+        double priceValue;
         try {
-            Double.parseDouble(costPrice);
+            priceValue = Double.parseDouble(price);
         } catch (NumberFormatException e) {
-            throw new ParseException(Messages.MESSAGE_INVALID_COSTPRICE_FORMAT);
+            throw new ParseException(Messages.MESSAGE_INVALID_PRICE_FORMAT);
         }
 
-        if (Double.parseDouble(costPrice) > 0) {
-            return Double.parseDouble(costPrice);
-        } else {
-            throw new ParseException(Messages.MESSAGE_INVALID_COSTPRICE_FORMAT);
-        }
-    }
-
-    /**
-     * Parses {@code String salesPrice} into a {@code Double}.
-     */
-    public static Double parseSalesPrice(String salesPrice) throws ParseException {
-        try {
-            Double.parseDouble(salesPrice);
-        } catch (NumberFormatException e) {
-            throw new ParseException(Messages.MESSAGE_INVALID_SALESPRICE_FORMAT);
+        if (priceValue < 0 || priceValue >= 10000000) {
+            throw new ParseException(Messages.MESSAGE_INVALID_PRICE_RANGE);
         }
 
-        if (Double.parseDouble(salesPrice) > 0) {
-            return Double.parseDouble(salesPrice);
-        } else {
-            throw new ParseException(Messages.MESSAGE_INVALID_SALESPRICE_FORMAT);
-        }
+        // Round off to 2 decimal places
+        return (double) Math.round(priceValue * 100) / 100;
     }
 
     /**

--- a/src/main/java/seedu/address/model/item/IdContainsNumberPredicate.java
+++ b/src/main/java/seedu/address/model/item/IdContainsNumberPredicate.java
@@ -1,6 +1,8 @@
 package seedu.address.model.item;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
@@ -10,16 +12,16 @@ import seedu.address.commons.util.StringUtil;
  * Only output items with id that matches exactly with the query
  */
 public class IdContainsNumberPredicate implements Predicate<Item> {
-    private final List<String> keynumbers;
+    private final Collection<Integer> keynumbers;
 
-    public IdContainsNumberPredicate(List<String> keynumbers) {
+    public IdContainsNumberPredicate(Collection<Integer> keynumbers) {
         this.keynumbers = keynumbers;
     }
 
     @Override
     public boolean test(Item item) {
         return keynumbers.stream()
-                .anyMatch(keynumbers -> StringUtil.containsWordIgnoreCase(item.getId().toString(), keynumbers));
+                .anyMatch(keynumber -> keynumber.equals(item.getId()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/item/IdContainsNumberPredicate.java
+++ b/src/main/java/seedu/address/model/item/IdContainsNumberPredicate.java
@@ -1,11 +1,7 @@
 package seedu.address.model.item;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
-
-import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that a {@code Item}'s {@code Id} matches any of the keywords given.

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -178,10 +178,8 @@ public class Item implements Displayable {
                 .append(getId())
                 .append("; count: ")
                 .append(getCount())
-                .append("; costPrice: ")
-                .append(getCostPrice())
-                .append("; salesPrice: ")
-                .append(getSalesPrice());
+                .append(String.format("; costPrice: $%.2f", getCostPrice()))
+                .append(String.format("; salesPrice: $%.2f", getSalesPrice()));
 
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -174,8 +174,7 @@ public class Item implements Displayable {
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(getName())
-                .append("; id: ")
-                .append(getId())
+                .append(String.format("; count: %06d", getId()))
                 .append("; count: ")
                 .append(getCount())
                 .append(String.format("; costPrice: $%.2f", getCostPrice()))

--- a/src/main/java/seedu/address/model/item/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/item/NameContainsKeywordsPredicate.java
@@ -17,9 +17,8 @@ public class NameContainsKeywordsPredicate implements Predicate<Item> {
 
     @Override
     public boolean test(Item item) {
-        boolean multipleWord = keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsMultipleWord(item.getName().fullName, keyword));
-        return multipleWord;
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.phrasesStartsWithQuery(item.getName().fullName, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/item/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/item/TagContainsKeywordsPredicate.java
@@ -1,10 +1,8 @@
 package seedu.address.model.item;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/model/item/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/item/TagContainsKeywordsPredicate.java
@@ -1,18 +1,20 @@
 package seedu.address.model.item;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
+import seedu.address.model.tag.Tag;
 
 /**
  * Tests that a {@code Item}'s {@code tag} matches any of the keywords given.
  */
 public class TagContainsKeywordsPredicate implements Predicate<Item> {
-    private final List<String> keywords;
+    private final Collection<Tag> keytags;
 
-    public TagContainsKeywordsPredicate(List<String> keywords) {
-        this.keywords = keywords;
+    public TagContainsKeywordsPredicate(Collection<Tag> keytags) {
+        this.keytags = keytags;
     }
 
     @Override
@@ -21,17 +23,15 @@ public class TagContainsKeywordsPredicate implements Predicate<Item> {
         if (item.getTags().isEmpty()) {
             return false;
         }
-        String itemTag = item.getTags().toString().substring(2, lengthOfItemTag - 2);
-        boolean multipleWord = keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsMultipleWord(itemTag, keyword));
-        return multipleWord;
+
+        return item.getTags().stream().anyMatch(keytags::contains);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof TagContainsKeywordsPredicate // instanceof handles nulls
-                && keywords.equals(((TagContainsKeywordsPredicate) other).keywords)); // state check
+                && keytags.equals(((TagContainsKeywordsPredicate) other).keytags)); // state check
     }
 
 }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -22,7 +22,7 @@ public class Tag {
     public Tag(String tagName) {
         requireNonNull(tagName);
         checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
-        this.tagName = tagName;
+        this.tagName = tagName.toLowerCase();
     }
 
     /**

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -24,7 +24,7 @@ public class SampleDataUtil {
                     getTagSet("baked"), 3.0, 5.0),
             new Item(new Name("Oreo Cheesecake"), 109128, 1,
                     getTagSet("desert"), 4.0, 5.0),
-            new Item(new Name("Strawberry Shortcake"), 1991287, 2,
+            new Item(new Name("Strawberry Shortcake"), 199127, 2,
                     getTagSet("desert"), 2.1, 3.2),
             new Item(new Name("Cold Brew Coffee"), 121858, 5,
                     getTagSet("beverage"), 3.2, 4.4),

--- a/src/main/java/seedu/address/ui/ItemCard.java
+++ b/src/main/java/seedu/address/ui/ItemCard.java
@@ -53,8 +53,8 @@ public class ItemCard extends UiPart<Region> {
         name.setText(item.getName().fullName);
         id.setText(String.format("#%06d", item.getId()));
         count.setText(String.format("Quantity: %d", item.getCount()));
-        costPrice.setText(String.format("Cost Price: $ %s", item.getCostPrice()));
-        salesPrice.setText(String.format("Sales Price: $ %s", item.getSalesPrice()));
+        costPrice.setText(String.format("Cost Price: $ %.2f", item.getCostPrice()));
+        salesPrice.setText(String.format("Sales Price: $ %.2f", item.getSalesPrice()));
         item.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -48,42 +48,7 @@ public class StringUtilTest {
     }
 
 
-    //---------------- Tests for containsWordIgnoreCase --------------------------------------
-
-    /*
-     * Invalid equivalence partitions for word: null, empty, multiple words
-     * Invalid equivalence partitions for sentence: null
-     * The four test cases below test one invalid input at a time.
-     */
-
-    @Test
-    public void containsWordIgnoreCase_nullWord_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> StringUtil.containsWordIgnoreCase("typical sentence", null));
-    }
-    @Test
-    public void containsMultipleWord_nullWord_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> StringUtil.containsMultipleWord("typical sentence", null));
-    }
-
-    @Test
-    public void containsWordIgnoreCase_emptyWord_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, "Word parameter cannot be empty", ()
-            -> StringUtil.containsWordIgnoreCase("typical sentence", "  "));
-    }
-    @Test
-    public void containsMultipleWord_emptyWord_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, "Word parameter cannot be empty", ()
-            -> StringUtil.containsMultipleWord("typical sentence", "  "));
-    }
-
-    @Test
-    public void containsWordIgnoreCase_nullSentence_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> StringUtil.containsWordIgnoreCase(null, "abc"));
-    }
-    @Test
-    public void containsMultipleWord_nullSentence_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> StringUtil.containsMultipleWord(null, "abc"));
-    }
+    //---------------- Tests for phrasesStartWithQuery --------------------------------------
 
     /*
      * Valid equivalence partitions for word:
@@ -100,108 +65,64 @@ public class StringUtilTest {
      * Possible scenarios returning true:
      *   - matches first word in sentence
      *   - last word in sentence
-     *   - middle word in sentence
-     *   - matches multiple words
+     *   - matches middle phrases
+     *   - partial matches
+     *   - matches phrases even if case different
      *
      * Possible scenarios returning false:
-     *   - query word matches part of a sentence word
-     *   - sentence word matches part of the query word
+     *   - query is a substring but not a prefix of the phrase (e.g. query: "bc" and sentence: "abc")
+     *   - only query's first word matches phrase (e.g. query: "aaa bbb" and sentence: "bbb ccc")
      *
      * The test method below tries to verify all above with a reasonably low number of test cases.
      */
     @Test
-    public void equalArray_validInputs_correctResult() {
+    public void phrasesStartWithQuery_validInputs_returnsTrue() {
         //one word matches
-        String [] first = {"aaa", "bbb", "Ccc"};
-        String [] second = {"aaa"};
-        assertTrue(StringUtil.equalArray(first, second));
-        //complete match
-        String [] first2 = {"aaa", "bbb", "Ccc"};
-        String [] second2 = {"aaa", "bbb", "Ccc"};
-        assertTrue(StringUtil.equalArray(first2, second2));
+        String sentence = "aaa bbb ccc";
+        String query = "aaa";
+        assertTrue(StringUtil.phrasesStartsWithQuery(sentence, query));
+        //two word match
+        String sentence2 = "aaa bbb ccc";
+        String query2 = "bbb ccc";
+        assertTrue(StringUtil.phrasesStartsWithQuery(sentence2, query2));
+        //middle phrase match
+        String sentence3 = "aaa bbb ccc ddd";
+        String query3 = "bbb ccc";
+        assertTrue(StringUtil.phrasesStartsWithQuery(sentence3, query3));
+        //partial word match
+        String sentence4 = "aaa bbb ccc ddd";
+        String query4 = "bbb c";
+        assertTrue(StringUtil.phrasesStartsWithQuery(sentence4, query4));
         //different case
-        String [] first3 = {"aaa", "bbb", "Ccc"};
-        String [] second3 = {"ccc"};
-        assertTrue(StringUtil.equalArray(first3, second3));
-        //empty string
-        String [] first4 = {"aaa", "bbb", "Ccc"};
-        String [] second4 = {};
-        assertFalse(StringUtil.equalArray(first4, second4));
-        //partial string
-        String [] first5 = {"aaa", "bbb", "Ccc"};
-        String [] second5 = {"aa"};
-        assertFalse(StringUtil.equalArray(first5, second5));
+        String sentence5 = "aaA bbb ccc";
+        String query5 = "aaa bbB";
+        assertTrue(StringUtil.phrasesStartsWithQuery(sentence5, query5));
     }
 
     @Test
-    public void equalArrayElements_validInputs_correctResult() {
-        //wrong index
-        String [] first = {"aaa", "bbb", "Ccc"};
-        String [] second = {"Ccc"};
-        assertFalse(StringUtil.equalArrayElements(first, second, 1));
-        //correct index
-        String [] first2 = {"aaa", "bbb", "Ccc"};
-        String [] second2 = {"Ccc"};
-        assertTrue(StringUtil.equalArrayElements(first2, second2, 2));
-        //different case
-        String [] first3 = {"aaa", "bbb", "Ccc"};
-        String [] second3 = {"ccc"};
-        assertTrue(StringUtil.equalArrayElements(first3, second3, 2));
-        //index out of bounds
-        String [] first4 = {"aaa", "bbb", "Ccc"};
-        String [] second4 = {};
-        assertFalse(StringUtil.equalArrayElements(first4, second4, 3));
-        //partial string
-        String [] first5 = {"aaa", "bbb", "Ccc"};
-        String [] second5 = {"aa"};
-        assertFalse(StringUtil.equalArrayElements(first5, second5, 1));
+    public void phrasesStartWithQuery_validInputs_returnsFalse() {
+        // substring match but not a prefix
+        String sentence = "abc def geh";
+        String query = "ef";
+        assertFalse(StringUtil.phrasesStartsWithQuery(sentence, query));
+        // only first word of query matches phrase
+        String sentence2 = "aaa bbb ccc";
+        String query2 = "bbb ddd";
+        assertFalse(StringUtil.phrasesStartsWithQuery(sentence2, query2));
     }
 
     @Test
-    public void containsWordIgnoreCase_validInputs_correctResult() {
-
-        // Empty sentence
-        assertFalse(StringUtil.containsWordIgnoreCase("", "abc")); // Boundary case
-        assertFalse(StringUtil.containsWordIgnoreCase("    ", "123"));
-
-        // Matches a partial word only
-        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
-        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bbbb")); // Query word bigger than sentence word
-
-        // Matches word in the sentence, different upper/lower case letters
-        assertTrue(StringUtil.containsWordIgnoreCase("aaa bBb ccc", "Bbb")); // First word (boundary case)
-        assertTrue(StringUtil.containsWordIgnoreCase("aaa bBb ccc@1", "CCc@1")); // Last word (boundary case)
-        assertTrue(StringUtil.containsWordIgnoreCase("  AAA   bBb   ccc  ", "aaa")); // Sentence has extra spaces
-        assertTrue(StringUtil.containsWordIgnoreCase("Aaa", "aaa")); // Only one word in sentence (boundary case)
-        assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "  ccc  ")); // Leading/trailing spaces
-
-        // Matches multiple words in sentence
-        assertTrue(StringUtil.containsWordIgnoreCase("AAA bBb ccc  bbb", "bbB"));
+    public void phrasesStartWithQuery_emptySentence_returnsFalse() {
+        String sentence = "";
+        String query = "aaa";
+        assertFalse(StringUtil.phrasesStartsWithQuery(sentence, query));
     }
 
-
     @Test
-    public void containsMultipleWord_validInputs_correctResult() {
-
-        // Empty sentence
-        assertFalse(StringUtil.containsMultipleWord("", "abc")); // Boundary case
-        assertFalse(StringUtil.containsMultipleWord("    ", "123"));
-
-        // Matches a partial word only
-        assertFalse(StringUtil.containsMultipleWord("aaa bbb ccc", "bb")); // Sentence word bigger than query word
-        assertFalse(StringUtil.containsMultipleWord("aaa bbb ccc", "bbbb")); // Query word bigger than sentence word
-
-        // Matches word in the sentence, different upper/lower case letters
-        assertTrue(StringUtil.containsMultipleWord("aaa bBb ccc", "Bbb")); // First word (boundary case)
-        assertTrue(StringUtil.containsMultipleWord("aaa bBb ccc@1", "CCc@1")); // Last word (boundary case)
-        assertTrue(StringUtil.containsMultipleWord("  AAA   bBb   ccc  ", "aaa")); // Sentence has extra spaces
-        assertTrue(StringUtil.containsMultipleWord("Aaa", "aaa")); // Only one word in sentence (boundary case)
-        assertTrue(StringUtil.containsMultipleWord("aaa bbb ccc", "  ccc  ")); // Leading/trailing spaces
-
-        // Matches multiple words in sentence
-        assertTrue(StringUtil.containsMultipleWord("AAA bBb ccc  bbb", "bbB"));
-        assertTrue(StringUtil.containsMultipleWord("AAA bBb ccc  bbb", "bbB ccc"));
-        assertTrue(StringUtil.containsMultipleWord("AAA bBb ccc  bbb", "bbB ccc bbb"));
+    public void phrasesStartWithQuery_emptyQuery_throwsIllegalArgument() {
+        String sentence = "aaa bbb ccc";
+        String query = "";
+        assertThrows(IllegalArgumentException.class, () -> StringUtil.phrasesStartsWithQuery(sentence, query));
     }
 
     //---------------- Tests for getDetails --------------------------------------

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -34,7 +34,7 @@ public class CommandTestUtil {
     public static final String VALID_NAME_DONUT = "Donut";
     public static final String VALID_NAME_100PLUS = "100Plus";
     public static final String VALID_NAME_H20 = "H20";
-    public static final String VALID_ID_BAGEL = "123";
+    public static final String VALID_ID_BAGEL = "094021";
     public static final String VALID_ID_DONUT = "789013";
     public static final String VALID_COUNT_BAGEL = "5";
     public static final String VALID_COUNT_DONUT = "6";

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -2,21 +2,18 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static seedu.address.commons.core.Messages.MESSAGE_ITEMS_LISTED_OVERVIEW;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 import static seedu.address.model.display.DisplayMode.DISPLAY_INVENTORY;
-import static seedu.address.model.display.DisplayMode.DISPLAY_OPEN_ORDER;
-import static seedu.address.testutil.TypicalItems.CHOCOCHIP;
-import static seedu.address.testutil.TypicalItems.DALGONA_COFFEE;
-import static seedu.address.testutil.TypicalItems.EGGNOG;
-import static seedu.address.testutil.TypicalItems.FOREST_CAKE;
+import static seedu.address.testutil.TypicalItems.APPLE_PIE;
+import static seedu.address.testutil.TypicalItems.BANANA_MUFFIN;
 import static seedu.address.testutil.TypicalItems.getTypicalInventory;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,8 +23,9 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.TransactionList;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.item.IdContainsNumberPredicate;
+import seedu.address.model.item.Item;
 import seedu.address.model.item.NameContainsKeywordsPredicate;
-import seedu.address.model.order.Order;
+import seedu.address.model.item.TagContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -38,121 +36,95 @@ public class FindCommandTest {
     private Model expectedModel = new ModelManager(getTypicalInventory(), new UserPrefs(),
             new TransactionList(), new BookKeeping());
 
+    private NameContainsKeywordsPredicate pieNamePredicate =
+            new NameContainsKeywordsPredicate(List.of(APPLE_PIE.getName().fullName));
+    private IdContainsNumberPredicate pieIdPredicate =
+            new IdContainsNumberPredicate(List.of(APPLE_PIE.getId()));
+    private TagContainsKeywordsPredicate pieTagPredicate =
+            new TagContainsKeywordsPredicate(APPLE_PIE.getTags());
+    private NameContainsKeywordsPredicate muffinNamePredicate =
+            new NameContainsKeywordsPredicate(List.of(BANANA_MUFFIN.getName().fullName));
+
+    // Returns a predicate that returns true if any of the given predicates will return true
+    private static Predicate<Item> combinePredicate(Predicate<Item>... predicates) {
+        return item -> {
+            for (int i = 0; i < predicates.length; i++) {
+                if (predicates[i].test(item)) {
+                    return true;
+                }
+            }
+            return false;
+        };
+    }
+
+    @Test
+    public void constructor_emptyList_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> new FindCommand(new ArrayList<>()));
+    }
+
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstNamePredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondNamePredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
-        IdContainsNumberPredicate firstIdPredicate =
-                new IdContainsNumberPredicate(Collections.singletonList("#140272"));
-        IdContainsNumberPredicate secondIdPredicate =
-                new IdContainsNumberPredicate(Collections.singletonList("#475272"));
 
+        FindCommand findNameCommand = new FindCommand(List.of(pieNamePredicate));
+        FindCommand findIdCommand = new FindCommand(List.of(pieTagPredicate));
 
-        FindCommand findNameFirstCommand = new FindCommand(firstNamePredicate);
-        FindCommand findNameSecondCommand = new FindCommand(secondNamePredicate);
-        FindCommand findIdFirstCommand = new FindCommand(firstIdPredicate);
-        FindCommand findIdSecondCommand = new FindCommand(secondIdPredicate);
+        // same object
+        assertEquals(findNameCommand, findNameCommand);
 
+        // same predicate
+        assertEquals(findNameCommand, new FindCommand(List.of(pieNamePredicate)));
 
-        // same Name type-> returns true
-        assertTrue(findNameFirstCommand.equals(findNameFirstCommand));
-
-        // same Id type-> returns true
-        assertTrue(findIdFirstCommand.equals(findIdFirstCommand));
-
-        // same Name values -> returns true
-        FindCommand findNameFirstCommandCopy = new FindCommand(firstNamePredicate);
-        assertTrue(findNameFirstCommand.equals(findNameFirstCommandCopy));
-
-        // same Id values -> returns true
-        FindCommand findIdFirstCommandCopy = new FindCommand(firstIdPredicate);
-        assertTrue(findIdFirstCommand.equals(findIdFirstCommandCopy));
-
-        // different Name types -> returns false
-        assertFalse(findNameFirstCommand.equals(1));
-
-        // different Id types -> returns false
-        assertFalse(findIdFirstCommand.equals(1));
+        // different types -> returns false
+        assertFalse(findNameCommand.equals(1));
 
         // null -> returns false
-        assertFalse(findNameFirstCommand.equals(null));
+        assertFalse(findNameCommand.equals(null));
 
-        // null -> returns false
-        assertFalse(findIdFirstCommand.equals(null));
-
-        // different Name -> returns false
-        assertFalse(findNameFirstCommand.equals(findNameSecondCommand));
-
-        // different Id -> returns false
-        assertFalse(findIdFirstCommand.equals(findIdSecondCommand));
+        // different predicates -> returns false
+        assertNotEquals(findNameCommand, findIdCommand);
     }
 
     @Test
-    public void execute_zeroNameKeywords_noItemFound() {
-        String expectedMessage = String.format(MESSAGE_ITEMS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicateName(" ");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredItemList(DISPLAY_INVENTORY, predicate);
+    public void execute_existentName_itemFound() {
+        String expectedMessage = String.format(MESSAGE_ITEMS_LISTED_OVERVIEW, 1);
+        FindCommand command = new FindCommand(List.of(pieNamePredicate));
+        expectedModel.updateFilteredItemList(DISPLAY_INVENTORY, pieNamePredicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredDisplayList());
     }
 
     @Test
-    public void execute_zeroIdKeywords_noItemFound() {
-        String expectedMessage = String.format(MESSAGE_ITEMS_LISTED_OVERVIEW, 0);
-        IdContainsNumberPredicate predicate = preparePredicateId(" ");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredItemList(DISPLAY_INVENTORY, predicate);
+    public void execute_existentId_itemFound() {
+        String expectedMessage = String.format(MESSAGE_ITEMS_LISTED_OVERVIEW, 1);
+        FindCommand command = new FindCommand(List.of(pieIdPredicate));
+        expectedModel.updateFilteredItemList(DISPLAY_INVENTORY, pieIdPredicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredDisplayList());
     }
 
     @Test
-    public void execute_multipleNameKeywords_multipleItemsFound() {
+    public void execute_existentTag_itemFound() {
         String expectedMessage = String.format(MESSAGE_ITEMS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicateName("Chocolate Egg Forest");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredItemList(DISPLAY_INVENTORY, predicate);
+        FindCommand command = new FindCommand(List.of(pieTagPredicate));
+        expectedModel.updateFilteredItemList(DISPLAY_INVENTORY, pieTagPredicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CHOCOCHIP, EGGNOG, FOREST_CAKE), model.getFilteredDisplayList());
     }
 
     @Test
-    public void execute_multipleIdKeywords_multipleItemsFound() {
+    public void execute_multiplePredicates_itemsFound() {
         String expectedMessage = String.format(MESSAGE_ITEMS_LISTED_OVERVIEW, 2);
-        IdContainsNumberPredicate predicate = preparePredicateId("444444 555555");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredItemList(DISPLAY_INVENTORY, predicate);
+        FindCommand command = new FindCommand(List.of(pieIdPredicate, muffinNamePredicate));
+
+        Predicate<Item> combinedPredicate = combinePredicate(pieIdPredicate, muffinNamePredicate);;
+        expectedModel.updateFilteredItemList(DISPLAY_INVENTORY, combinedPredicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CHOCOCHIP, DALGONA_COFFEE), model.getFilteredDisplayList());
     }
 
     @Test
-    public void execute_displayNotInInventoryMode_failure() {
-        IdContainsNumberPredicate predicate = preparePredicateId("444444 555555");
-        FindCommand command = new FindCommand(predicate);
+    public void execute_multiplePredicatesSameItem_itemFound() {
+        String expectedMessage = String.format(MESSAGE_ITEMS_LISTED_OVERVIEW, 1);
+        FindCommand command = new FindCommand(List.of(pieIdPredicate, pieNamePredicate));
 
-        model.setOrder(new Order());
-        model.updateFilteredDisplayList(DISPLAY_OPEN_ORDER, PREDICATE_SHOW_ALL_ITEMS);
-        String expectedMessage = FindCommand.MESSAGE_INVENTORY_NOT_DISPLAYED;
-
-        assertCommandFailure(command, model, expectedMessage);
-    }
-
-    /**
-     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
-     */
-    private NameContainsKeywordsPredicate preparePredicateName(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
-    }
-
-    /**
-     * Parses {@code userInput} into a {@code IdContainsKeywordsPredicate}.
-     */
-    private IdContainsNumberPredicate preparePredicateId(String userInput) {
-        return new IdContainsNumberPredicate(Arrays.asList(userInput.split("\\s+")));
+        expectedModel.updateFilteredItemList(DISPLAY_INVENTORY, pieIdPredicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
     }
 
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -103,7 +103,7 @@ public class AddressBookParserTest {
         List<String> keywords = Arrays.asList("foo");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "foo");
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        assertEquals(new FindCommand(List.of(new NameContainsKeywordsPredicate(keywords))), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -21,19 +21,23 @@ public class ParserUtilTest {
     private static final String INVALID_NAME = "Pudding^";
     private static final String INVALID_TAG = "#nice";
     private static final String INVALID_COUNT_ZERO = "0";
-    private static final String INVALID_COUNT_1 = "sweet";
-    private static final String INVALID_COUNT_2 = "-1";
-    private static final String INVALID_Id = "abc";
-    private static final String INVALID_Id_2 = "-1";
-    private static final String INVALID_Id_3 = "123";
+    private static final String INVALID_COUNT_FORMAT = "sweet";
+    private static final String INVALID_COUNT_NEGATIVE = "-1";
+    private static final String INVALID_ID_FORMAT = "abc";
+    private static final String INVALID_ID_NEGATIVE = "-1";
+    private static final String INVALID_PRICE_FORMAT = "abc";
+    private static final String INVALID_PRICE_NEGATIVE = "-1";
+    private static final String INVALID_PRICE_OVERFLOW = "999999999.1";
 
     private static final String VALID_NAME = "Pudding";
     private static final String VALID_TAG_1 = "nice";
     private static final String VALID_TAG_2 = "sweet";
     private static final String VALID_COUNT_1 = "2";
     private static final String VALID_COUNT_2 = "12";
-    private static final String VALID_Id_1 = "223";
-    private static final String VALID_Id_2 = "122489";
+    private static final String VALID_ID_1 = "223";
+    private static final String VALID_ID_2 = "122489";
+    private static final String VALID_PRICE_1 = "1.21";
+    private static final String VALID_PRICE_2 = "12.2121";  // Should be rounded to 2 decimal places
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -133,7 +137,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseCount_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseCount(INVALID_COUNT_1));
+        assertThrows(ParseException.class, () -> ParserUtil.parseCount(INVALID_COUNT_FORMAT));
     }
 
     @Test
@@ -143,7 +147,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseCount_negativeNumber_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseCount(INVALID_COUNT_2));
+        assertThrows(ParseException.class, () -> ParserUtil.parseCount(INVALID_COUNT_NEGATIVE));
     }
 
     @Test
@@ -167,25 +171,54 @@ public class ParserUtilTest {
 
     @Test
     public void parseId_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseId(INVALID_Id));
+        assertThrows(ParseException.class, () -> ParserUtil.parseId(INVALID_ID_FORMAT));
     }
 
     @Test
     public void parseId_negativeValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseId(INVALID_Id_2));
+        assertThrows(ParseException.class, () -> ParserUtil.parseId(INVALID_ID_NEGATIVE));
     }
 
     @Test
     public void parseId_validId_returnsId() throws Exception {
-        Integer expectedId = Integer.parseInt(VALID_Id_1);
-        Integer actualId = ParserUtil.parseId(VALID_Id_1);
+        Integer expectedId = Integer.parseInt(VALID_ID_1);
+        Integer actualId = ParserUtil.parseId(VALID_ID_1);
         assertEquals(expectedId, actualId);
     }
 
     @Test
     public void parseId_validId2_returnsId() throws Exception {
-        Integer expectedId = Integer.parseInt(VALID_Id_2);
-        Integer actualId = ParserUtil.parseId(VALID_Id_2);
+        Integer expectedId = Integer.parseInt(VALID_ID_2);
+        Integer actualId = ParserUtil.parseId(VALID_ID_2);
         assertEquals(expectedId, actualId);
+    }
+
+    @Test
+    public void parsePrice_validPrices_returnsPrice() throws Exception {
+        // 2 decimal places
+        double expectedPrice = Double.parseDouble(VALID_PRICE_1);
+        double actualPrice = ParserUtil.parseId(VALID_PRICE_1);
+        assertEquals(expectedPrice, actualPrice);
+
+        // Extra decimal places
+        expectedPrice = Math.round(Double.parseDouble(VALID_PRICE_1) / 100) * 100;
+        actualPrice = ParserUtil.parseId(VALID_PRICE_1);
+        assertEquals(expectedPrice, actualPrice);
+    }
+
+    @Test
+    public void parsePrice_negativePrice_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseId(INVALID_PRICE_NEGATIVE));
+    }
+
+    @Test
+    public void parsePrice_largePrice_throwsParseException()  {
+        assertThrows(ParseException.class, () -> ParserUtil.parseId(INVALID_PRICE_OVERFLOW));
+    }
+
+
+    @Test
+    public void parsePrice_notNumbers_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseId(INVALID_PRICE_FORMAT));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -25,6 +25,7 @@ public class ParserUtilTest {
     private static final String INVALID_COUNT_NEGATIVE = "-1";
     private static final String INVALID_ID_FORMAT = "abc";
     private static final String INVALID_ID_NEGATIVE = "-1";
+    private static final String INVALID_ID_SHORTER = "123";
     private static final String INVALID_PRICE_FORMAT = "abc";
     private static final String INVALID_PRICE_NEGATIVE = "-1";
     private static final String INVALID_PRICE_OVERFLOW = "999999999.1";
@@ -34,10 +35,9 @@ public class ParserUtilTest {
     private static final String VALID_TAG_2 = "sweet";
     private static final String VALID_COUNT_1 = "2";
     private static final String VALID_COUNT_2 = "12";
-    private static final String VALID_ID_1 = "223";
-    private static final String VALID_ID_2 = "122489";
+    private static final String VALID_ID = "123456";
     private static final String VALID_PRICE_1 = "1.21";
-    private static final String VALID_PRICE_2 = "12.2121";  // Should be rounded to 2 decimal places
+    private static final String VALID_PRICE_2 = "12.2121"; // Should be rounded to 2 decimal places
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -180,16 +180,14 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseId_validId_returnsId() throws Exception {
-        Integer expectedId = Integer.parseInt(VALID_ID_1);
-        Integer actualId = ParserUtil.parseId(VALID_ID_1);
-        assertEquals(expectedId, actualId);
+    public void parseId_lessThan6Digits_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseId(INVALID_ID_SHORTER));
     }
 
     @Test
-    public void parseId_validId2_returnsId() throws Exception {
-        Integer expectedId = Integer.parseInt(VALID_ID_2);
-        Integer actualId = ParserUtil.parseId(VALID_ID_2);
+    public void parseId_validId_returnsId() throws Exception {
+        Integer expectedId = Integer.parseInt(VALID_ID);
+        Integer actualId = ParserUtil.parseId(VALID_ID);
         assertEquals(expectedId, actualId);
     }
 
@@ -197,12 +195,12 @@ public class ParserUtilTest {
     public void parsePrice_validPrices_returnsPrice() throws Exception {
         // 2 decimal places
         double expectedPrice = Double.parseDouble(VALID_PRICE_1);
-        double actualPrice = ParserUtil.parseId(VALID_PRICE_1);
+        double actualPrice = ParserUtil.parsePrice(VALID_PRICE_1);
         assertEquals(expectedPrice, actualPrice);
 
         // Extra decimal places
-        expectedPrice = Math.round(Double.parseDouble(VALID_PRICE_1) / 100) * 100;
-        actualPrice = ParserUtil.parseId(VALID_PRICE_1);
+        expectedPrice = Math.round(Double.parseDouble(VALID_PRICE_2) * 100) / 100.0;
+        actualPrice = ParserUtil.parsePrice(VALID_PRICE_2);
         assertEquals(expectedPrice, actualPrice);
     }
 
@@ -212,7 +210,7 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parsePrice_largePrice_throwsParseException()  {
+    public void parsePrice_largePrice_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseId(INVALID_PRICE_OVERFLOW));
     }
 

--- a/src/test/java/seedu/address/model/item/IdContainsNumberPredicateTest.java
+++ b/src/test/java/seedu/address/model/item/IdContainsNumberPredicateTest.java
@@ -15,8 +15,8 @@ public class IdContainsNumberPredicateTest {
 
     @Test
     public void equals() {
-        List<String> firstPredicateKeywordList = Collections.singletonList("140121");
-        List<String> secondPredicateKeywordList = Arrays.asList("140252", "124535");
+        List<Integer> firstPredicateKeywordList = Collections.singletonList(140121);
+        List<Integer> secondPredicateKeywordList = Arrays.asList(140121, 124535);
 
         IdContainsNumberPredicate firstPredicate = new IdContainsNumberPredicate(firstPredicateKeywordList);
         IdContainsNumberPredicate secondPredicate = new IdContainsNumberPredicate(secondPredicateKeywordList);
@@ -41,7 +41,7 @@ public class IdContainsNumberPredicateTest {
     @Test
     public void test_idContainsNumber_returnsTrue() {
         // exact
-        IdContainsNumberPredicate predicate = new IdContainsNumberPredicate(Collections.singletonList("140121"));
+        IdContainsNumberPredicate predicate = new IdContainsNumberPredicate(Collections.singletonList(140121));
         assertTrue(predicate.test(new ItemBuilder().withId("140121").build()));
     }
 
@@ -52,16 +52,12 @@ public class IdContainsNumberPredicateTest {
         assertFalse(predicate.test(new ItemBuilder().withId("147564").build()));
 
         // partial match
-        predicate = new IdContainsNumberPredicate(Arrays.asList("140342", "140812"));
+        predicate = new IdContainsNumberPredicate(Arrays.asList(140342, 140812));
         assertFalse(predicate.test(new ItemBuilder().withId("140").build()));
 
         // completely doesn't match
-        predicate = new IdContainsNumberPredicate(Arrays.asList("140242", "243812"));
+        predicate = new IdContainsNumberPredicate(Arrays.asList(140242, 243812));
         assertFalse(predicate.test(new ItemBuilder().withId("203523").build()));
-
-        // Keywords match name and tag, but does not match id
-        predicate = new IdContainsNumberPredicate(Arrays.asList("12345", "baked"));
-        assertFalse(predicate.test(new ItemBuilder().withName("Apple Pie").withId("12346").withTags("baked").build()));
     }
 }
 

--- a/src/test/java/seedu/address/testutil/ItemUtil.java
+++ b/src/test/java/seedu/address/testutil/ItemUtil.java
@@ -36,7 +36,7 @@ public class ItemUtil {
     public static String getDeleteCommand(Item item) {
         return DeleteCommand.COMMAND_WORD
                 + " " + item.getName()
-                + " " + PREFIX_ID + item.getId();
+                + " " + PREFIX_ID + String.format("%06d", item.getId());
     }
 
     /**
@@ -45,7 +45,7 @@ public class ItemUtil {
     public static String getRemoveCommand(Item item) {
         return RemoveCommand.COMMAND_WORD
                 + " " + item.getName()
-                + " " + PREFIX_ID + item.getId()
+                + " " + PREFIX_ID + String.format("%06d", item.getId())
                 + " " + PREFIX_COUNT + item.getCount();
     }
 


### PR DESCRIPTION
The practical exam dry run has revealed quite a number of parsing related bugs. Notably, parsing of id and price is not robust enough. The parsing of `FindCommand` is also problematic and needs an overhaul (e.g. parsing of id and name simultaneously is not supported).

This PR fixes the following:
1. **Parsing of price.** Allows the range `0 <= price < 10,000,000`. Values are rounded to 2 decimal places.
2. **Parsing of id** The padding of ids with leading zeroes is now better enforced.
3. **Parsing of `FindCommand`** Parsing of different fields is supported now.

Miscellaneous edits:
- Partial name matching in FindCommand is supported now
- Redundant methods in `StringUtil` has been deleted. The different item predicates were originally using them incorrectly.