### PR TITLE
Enhance arg multimap

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,7 +10,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_ITEM_DISPLAYED_INDEX = "The item index provided is invalid";
     public static final String MESSAGE_ITEMS_LISTED_OVERVIEW = "%1$d items listed!";
     public static final String MESSAGE_INVALID_COUNT_INTEGER = "The count provided must be positive!";
-    public static final String MESSAGE_INVALID_COUNT_FORMAT = "The count provided must be integer!";
+    public static final String MESSAGE_INVALID_COUNT_FORMAT = "The count provided must be an integer!\n"
+            + "Minimum: 1\n" + "Maximum: 2,147,483,647";
     public static final String MESSAGE_INVALID_COUNT_INDEX = "The index provided must be a number (can't be >1 number)"
             + " and cannot be 0 or negative!";
     public static final String MESSAGE_INVALID_PRICE_FORMAT = "Prices provided must be numerical values!";

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -19,5 +19,4 @@ public class Messages {
     public static final String MESSAGE_INVALID_ID_FORMAT = "The id provided must be integer!";
     public static final String MESSAGE_INVALID_ID_LENGTH_AND_SIGN = "The id provided must be positive"
             + " and at most 6 digits!";
-    public static final String MESSAGE_NAME_SPECIFIED_TWICE = "Name field is specified twice!";
 }

--- a/src/main/java/seedu/address/logic/parser/AddToOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddToOrderCommandParser.java
@@ -1,11 +1,9 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_NAME_SPECIFIED_TWICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COSTPRICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALESPRICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -24,7 +22,7 @@ public class AddToOrderCommandParser implements Parser<AddToOrderCommand> {
     @Override
     public AddToOrderCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ID, PREFIX_COUNT, PREFIX_TAG,
+                ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_COUNT, PREFIX_TAG,
                         PREFIX_COSTPRICE, PREFIX_SALESPRICE);
 
         if (argMultimap.getValue(PREFIX_ID).isEmpty() && argMultimap.getPreamble().isEmpty()) {
@@ -32,10 +30,6 @@ public class AddToOrderCommandParser implements Parser<AddToOrderCommand> {
         }
 
         ItemDescriptor toAddDescriptor = new ItemDescriptor();
-        // if both name flag and prefix are present
-        if (!argMultimap.getPreamble().isEmpty() && argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            throw new ParseException(MESSAGE_NAME_SPECIFIED_TWICE + "\n" + AddToOrderCommand.MESSAGE_USAGE);
-        }
 
         // Parse preamble
         if (!argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -1,13 +1,11 @@
 package seedu.address.logic.parser;
 
-import seedu.address.logic.parser.exceptions.ParseException;
-
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+
+import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Tokenizes arguments string of the form: {@code preamble <prefix>value <prefix>value ...}<br>
@@ -28,8 +26,8 @@ public class ArgumentTokenizer {
      *
      * @param argsString Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}
      * @param prefixes   Expected prefixes
-     * @throws ParseException if an unexpected prefix is detected
      * @return           ArgumentMultimap object that maps prefixes to their arguments
+     * @throws           ParseException if an unexpected prefix is detected
      */
     public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) throws ParseException {
         List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
@@ -43,7 +41,8 @@ public class ArgumentTokenizer {
      * @param prefixes   Expected prefixes
      * @return           List of zero-based prefix positions in the given arguments string
      */
-    private static List<PrefixPosition> findAllPrefixPositions(String argsString, Prefix... prefixes) throws ParseException {
+    private static List<PrefixPosition> findAllPrefixPositions(String argsString, Prefix... prefixes)
+            throws ParseException {
         Matcher m = Pattern.compile(PREFIX_REGEX).matcher(argsString);
 
         List<PrefixPosition> prefixPositionList = new ArrayList<>();

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -1,8 +1,12 @@
 package seedu.address.logic.parser;
 
+import seedu.address.logic.parser.exceptions.ParseException;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -15,15 +19,19 @@ import java.util.stream.Collectors;
  */
 public class ArgumentTokenizer {
 
+    // Regex matching any series of non-whitespace characters followed by "/"
+    public static final String PREFIX_REGEX = "[^\\s]*/";
+
     /**
      * Tokenizes an arguments string and returns an {@code ArgumentMultimap} object that maps prefixes to their
-     * respective argument values. Only the given prefixes will be recognized in the arguments string.
+     * respective argument values.
      *
      * @param argsString Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}
-     * @param prefixes   Prefixes to tokenize the arguments string with
+     * @param prefixes   Expected prefixes
+     * @throws ParseException if an unexpected prefix is detected
      * @return           ArgumentMultimap object that maps prefixes to their arguments
      */
-    public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) {
+    public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) throws ParseException {
         List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
         return extractArguments(argsString, positions);
     }
@@ -32,47 +40,25 @@ public class ArgumentTokenizer {
      * Finds all zero-based prefix positions in the given arguments string.
      *
      * @param argsString Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}
-     * @param prefixes   Prefixes to find in the arguments string
+     * @param prefixes   Expected prefixes
      * @return           List of zero-based prefix positions in the given arguments string
      */
-    private static List<PrefixPosition> findAllPrefixPositions(String argsString, Prefix... prefixes) {
-        return Arrays.stream(prefixes)
-                .flatMap(prefix -> findPrefixPositions(argsString, prefix).stream())
-                .collect(Collectors.toList());
-    }
+    private static List<PrefixPosition> findAllPrefixPositions(String argsString, Prefix... prefixes) throws ParseException {
+        Matcher m = Pattern.compile(PREFIX_REGEX).matcher(argsString);
 
-    /**
-     * {@see findAllPrefixPositions}
-     */
-    private static List<PrefixPosition> findPrefixPositions(String argsString, Prefix prefix) {
-        List<PrefixPosition> positions = new ArrayList<>();
+        List<PrefixPosition> prefixPositionList = new ArrayList<>();
+        while (m.find()) {
+            Prefix found = new Prefix(m.group());
 
-        int prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), 0);
-        while (prefixPosition != -1) {
-            PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition);
-            positions.add(extendedPrefix);
-            prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition);
+            // If prefix is unexpected, throw parse exception
+            if (!List.of(prefixes).contains(found)) {
+                throw new ParseException(String.format("Unexpected prefix identified: %s", m.group()));
+            }
+
+            prefixPositionList.add(new PrefixPosition(found, m.start()));
         }
 
-        return positions;
-    }
-
-    /**
-     * Returns the index of the first occurrence of {@code prefix} in
-     * {@code argsString} starting from index {@code fromIndex}. An occurrence
-     * is valid if there is a whitespace before {@code prefix}. Returns -1 if no
-     * such occurrence can be found.
-     *
-     * E.g if {@code argsString} = "e/hip/900", {@code prefix} = "p/" and
-     * {@code fromIndex} = 0, this method returns -1 as there are no valid
-     * occurrences of "p/" with whitespace before it. However, if
-     * {@code argsString} = "e/hi p/900", {@code prefix} = "p/" and
-     * {@code fromIndex} = 0, this method returns 5.
-     */
-    private static int findPrefixPosition(String argsString, String prefix, int fromIndex) {
-        int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
-        return prefixIndex == -1 ? -1
-                : prefixIndex + 1; // +1 as offset for whitespace
+        return prefixPositionList;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -49,9 +49,8 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         // Add name predicate if name(s) specified
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            predicates.add(
-                    new NameContainsKeywordsPredicate(argMultimap.getAllValues(PREFIX_NAME))
-            );
+            predicates.add(new NameContainsKeywordsPredicate(
+                    argMultimap.getAllValues(PREFIX_NAME)));
         }
 
         // Add id predicate if id(s) specified

--- a/src/main/java/seedu/address/logic/parser/RemoveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_NAME_SPECIFIED_TWICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COSTPRICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
@@ -30,10 +29,6 @@ public class RemoveCommandParser implements Parser<RemoveCommand> {
 
         if (argMultimap.getValue(PREFIX_ID).isEmpty() && argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveCommand.MESSAGE_USAGE));
-        }
-
-        if (argMultimap.getValue(PREFIX_NAME).isPresent() && !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_NAME_SPECIFIED_TWICE, RemoveCommand.MESSAGE_USAGE));
         }
 
         ItemDescriptor toRemoveDescriptor = new ItemDescriptor();

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -32,13 +32,10 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_BAGEL = "Bagel";
     public static final String VALID_NAME_DONUT = "Donut";
-    public static final String VALID_NAME_100PLUS = "100Plus";
-    public static final String VALID_NAME_H20 = "H20";
     public static final String VALID_ID_BAGEL = "094021";
     public static final String VALID_ID_DONUT = "789013";
     public static final String VALID_COUNT_BAGEL = "5";
     public static final String VALID_COUNT_DONUT = "6";
-    public static final String VALID_COUNT_ONE = "1";
     public static final String VALID_COSTPRICE_BAGEL = "5.0";
     public static final String VALID_COSTPRICE_DONUT = "6.0";
     public static final String VALID_SALESPRICE_BAGEL = "6.0";
@@ -52,17 +49,12 @@ public class CommandTestUtil {
     public static final String ID_DESC_DONUT = " " + PREFIX_ID + VALID_ID_DONUT;
     public static final String COUNT_DESC_BAGEL = " " + PREFIX_COUNT + VALID_COUNT_BAGEL;
     public static final String COUNT_DESC_DONUT = " " + PREFIX_COUNT + VALID_COUNT_DONUT;
-    public static final String COUNT_DESC_ONE = " " + PREFIX_COUNT + VALID_COUNT_ONE;
-    public static final String COUNT_DESC_MAX_INT = " " + PREFIX_COUNT + String.valueOf(Integer.MAX_VALUE);
     public static final String SALESPRICE_DESC_BAGEL = " " + PREFIX_SALESPRICE + VALID_SALESPRICE_BAGEL;
-    public static final String SALESPRICE_DESC_DONUT = " " + PREFIX_SALESPRICE + VALID_SALESPRICE_DONUT;
     public static final String COSTPRICE_DESC_BAGEL = " " + PREFIX_COSTPRICE + VALID_COSTPRICE_BAGEL;
-    public static final String COSTPRICE_DESC_DONUT = " " + PREFIX_COSTPRICE + VALID_COSTPRICE_DONUT;
     public static final String TAG_DESC_BAKED = " " + PREFIX_TAG + VALID_TAG_BAKED;
     public static final String TAG_DESC_POPULAR = " " + PREFIX_TAG + VALID_TAG_POPULAR;
 
     public static final String INVALID_NAME_SPECIAL_CHAR = "Cake$";
-    public static final String INVALID_NAME_EMPTY_STRING = "";
     public static final String INVALID_NAME_DESC =
             " " + PREFIX_NAME + INVALID_NAME_SPECIAL_CHAR; // '&' not allowed in names
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
@@ -71,15 +63,8 @@ public class CommandTestUtil {
     public static final String INVALID_ID_NEGATIVE_NUMBER = " " + PREFIX_ID + "-123232";
     public static final String INVALID_ID_SEVEN_DIGITS = " " + PREFIX_ID + "1234567";
     public static final String INVALID_COUNT_LETTER = " " + PREFIX_COUNT + "abc";
-    public static final String INVALID_COUNT_SPECIAL_CHAR = " " + PREFIX_COUNT + "1234$";
     public static final String INVALID_COUNT_ZERO = " " + PREFIX_COUNT + "0";
     public static final String INVALID_COUNT_NEGATIVE_VALUE = " " + PREFIX_COUNT + "-1";
-    public static final String INVALID_COUNT_BEYOND_MAX_INT = " " + PREFIX_COUNT + "2147483648";
-    public static final String INVALID_SALESPRICE_BAGEL = " " + PREFIX_SALESPRICE + "asdf";
-    public static final String INVALID_COSTPRICE_BAGEL = " " + PREFIX_COSTPRICE + "asdf";
-
-    public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
-    public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
     public static final ItemDescriptor DESC_BAGEL;
     public static final ItemDescriptor DESC_DONUT;

--- a/src/test/java/seedu/address/logic/parser/AddToOrderCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddToOrderCommandParserTest.java
@@ -2,14 +2,10 @@ package seedu.address.logic.parser;
 
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_NAME_SPECIFIED_TWICE;
 import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_DONUT;
-import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_MAX_INT;
-import static seedu.address.logic.commands.CommandTestUtil.COUNT_DESC_ONE;
 import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_DONUT;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_COUNT_BEYOND_MAX_INT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_COUNT_LETTER;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_COUNT_NEGATIVE_VALUE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_COUNT_ZERO;
@@ -21,13 +17,8 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_SPECIAL_
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_BAKED;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_POPULAR;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNT_BAGEL;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNT_DONUT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BAGEL;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_DONUT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_100PLUS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_DONUT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -41,43 +32,6 @@ import seedu.address.testutil.ItemDescriptorBuilder;
 
 public class AddToOrderCommandParserTest {
     private AddToOrderCommandParser parser = new AddToOrderCommandParser();
-
-    @Test
-    public void parse_nameEp() {
-
-        // EP: valid name: alphabetical string
-        // Heuristic: other inputs valid EP appear at least once
-        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
-                .withName(VALID_NAME_BAGEL)
-                .withId(VALID_ID_BAGEL)
-                .withCount(VALID_COUNT_BAGEL)
-                .build();
-
-        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_BAGEL,
-                new AddToOrderCommand(expectedDescriptor));
-
-        // EP: valid name: alphanumeric string
-        // Heuristic: other inputs valid EP appear at least once
-        expectedDescriptor = new ItemDescriptorBuilder()
-                .withName(VALID_NAME_100PLUS)
-                .withId(VALID_ID_DONUT)
-                .withCount(VALID_COUNT_DONUT)
-                .build();
-
-        assertParseSuccess(parser, VALID_NAME_100PLUS + ID_DESC_DONUT + COUNT_DESC_DONUT,
-                new AddToOrderCommand(expectedDescriptor));
-
-        String invalidNameErrorMsg =
-                "Names should only contain alphanumeric characters and spaces, and it should not be blank";
-        // EP: invalid name: empty string for name.
-        //assertParseFailure(parser, INVALID_NAME_EMPTY_STRING + ID_DESC_BAGEL + COUNT_DESC_BAGEL, invalidNameErrorMsg);
-
-        // EP: invalid name: special chars involved. e.g."cake$"
-        //assertParseFailure(parser, INVALID_NAME_SPECIAL_CHAR + ID_DESC_BAGEL + COUNT_DESC_BAGEL, invalidNameErrorMsg);
-
-        // EP: invalid name: name comes with prefix.
-        //assertParseFailure(parser, INVALID_NAME_DESC + ID_DESC_BAGEL + COUNT_DESC_BAGEL, invalidNameErrorMsg);
-    }
 
     @Test
     public void parse_idEp() {
@@ -110,49 +64,6 @@ public class AddToOrderCommandParserTest {
         // EP: invalid id: contains special chars
         assertParseFailure(parser, VALID_NAME_BAGEL + INVALID_ID_LETTER + COUNT_DESC_BAGEL, notIntegerErrorMsg);
     }
-
-    @Test
-    public void parse_countEp() {
-        // EP: valid count: boundary value 1
-        ItemDescriptor expectedDescriptor = new ItemDescriptorBuilder()
-                .withName(VALID_NAME_BAGEL)
-                .withId(VALID_ID_BAGEL)
-                .withCount("1")
-                .build();
-
-        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_ONE,
-                new AddToOrderCommand(expectedDescriptor));
-
-        // EP: valid count: boundary value Integer.MAX_VALUE
-        expectedDescriptor = new ItemDescriptorBuilder()
-                .withName(VALID_NAME_BAGEL)
-                .withId(VALID_ID_BAGEL)
-                .withCount(String.valueOf(Integer.MAX_VALUE))
-                .build();
-
-        assertParseSuccess(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + COUNT_DESC_MAX_INT,
-                new AddToOrderCommand(expectedDescriptor));
-
-        // EP: invalid count: boundary value 0
-        String zeroCountErrorMsg = "The count provided must be positive!";
-        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + INVALID_COUNT_ZERO,
-                zeroCountErrorMsg);
-
-        // EP: invalid count: boundary value -1
-        String negativeCountErrorMsg = "The count provided must be positive!";
-        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + INVALID_COUNT_NEGATIVE_VALUE,
-                negativeCountErrorMsg);
-
-        // EP: invalid count: boundary value Integer.MAX_VALUE + 1
-        String notIntegerErrorMsg = "The count provided must be integer!";
-        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + INVALID_COUNT_BEYOND_MAX_INT,
-                notIntegerErrorMsg);
-
-        // EP: invalid count: not a number
-        assertParseFailure(parser, VALID_NAME_BAGEL + ID_DESC_BAGEL + INVALID_COUNT_LETTER,
-                notIntegerErrorMsg);
-    }
-
 
     @Test
     public void parse_allFieldsPresent_success() {
@@ -219,14 +130,6 @@ public class AddToOrderCommandParserTest {
 
         // both name and id prefix missing
         assertParseFailure(parser, COUNT_DESC_BAGEL, expectedMessage);
-    }
-
-    @Test
-    public void parse_twoNameFields_failure() {
-        String expectedMessage = String.format(MESSAGE_NAME_SPECIFIED_TWICE + "\n" + AddToOrderCommand.MESSAGE_USAGE);
-
-        // both name and id prefix missing
-        assertParseFailure(parser, VALID_NAME_BAGEL + " " + PREFIX_NAME + VALID_NAME_DONUT, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.parser.exceptions.ParseException;
 
 public class ArgumentTokenizerTest {

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -3,25 +3,23 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import seedu.address.logic.parser.exceptions.ParseException;
 
 public class ArgumentTokenizerTest {
 
-    private final Prefix unknownPrefix = new Prefix("--u");
+    //private final Prefix unknownPrefix = new Prefix("--u");
     private final Prefix pSlash = new Prefix("p/");
-    private final Prefix dashT = new Prefix("-t");
-    private final Prefix hatQ = new Prefix("^Q");
+    private final Prefix dSlash = new Prefix("d/");
+    private final Prefix wordSlash = new Prefix("word/");
 
-    @Test
-    public void tokenize_emptyArgsString_noValues() {
-        String argsString = "  ";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
-
-        assertPreambleEmpty(argMultimap);
-        assertArgumentAbsent(argMultimap, pSlash);
-    }
+    private final String wordParameter1 = "Argument";
+    private final String wordParameter2 = "Argument";
+    private final String sentenceParameter1 = "Argument value with spaces";
+    private final String sentenceParameter2 = "Another argument value";
 
     private void assertPreamblePresent(ArgumentMultimap argMultimap, String expectedPreamble) {
         assertEquals(expectedPreamble, argMultimap.getPreamble());
@@ -30,6 +28,7 @@ public class ArgumentTokenizerTest {
     private void assertPreambleEmpty(ArgumentMultimap argMultimap) {
         assertTrue(argMultimap.getPreamble().isEmpty());
     }
+
 
     /**
      * Asserts all the arguments in {@code argMultimap} with {@code prefix} match the {@code expectedValues}
@@ -53,87 +52,133 @@ public class ArgumentTokenizerTest {
         assertFalse(argMultimap.getValue(prefix).isPresent());
     }
 
+    /* Equivalence Partitions:
+            Expected Prefixes:
+                - No prefixes
+                - Single character prefixes
+                - Multiple character prefixes
+                - Prefixes not in arg string
+
+            Preamble:
+                - Empty string
+                - Single word
+                - Multiple word
+
+            Parameters:
+                - Empty parameter
+                - Single word
+                - Multiple word
+                - Single word with trailing / leading spaces
+                - Multiple word with trailing / leading spaces
+
+        The following test cases attempts to cover all partitions in an efficient manner.
+     */
+
     @Test
-    public void tokenize_noPrefixes_allTakenAsPreamble() {
-        String argsString = "  some random string /t tag with leading and trailing spaces ";
+    public void tokenize_emptyArgsString_noValues() throws ParseException {
+        String argsString = "  ";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
+
+        assertPreambleEmpty(argMultimap);
+        assertArgumentAbsent(argMultimap, pSlash);
+    }
+
+    @Test
+    public void tokenize_noPrefixes_allTakenAsPreamble() throws ParseException {
+        String argsString = "  some random string with trailing space ";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString);
 
         // Same string expected as preamble, but leading/trailing spaces should be trimmed
         assertPreamblePresent(argMultimap, argsString.trim());
-
     }
 
     @Test
-    public void tokenize_oneArgument() {
-        // Preamble present
-        String argsString = "  Some preamble string p/ Argument value ";
+    public void tokenize_oneArgument() throws ParseException {
+        // Preamble absent, empty values.
+        String argsString = pSlash.getPrefix();
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
-        assertPreamblePresent(argMultimap, "Some preamble string");
-        assertArgumentPresent(argMultimap, pSlash, "Argument value");
+        assertPreambleEmpty(argMultimap);
+        assertArgumentPresent(argMultimap, pSlash, "");
 
-        // No preamble
-        argsString = " p/   Argument value ";
+        // Preamble present, word values.
+        argsString = wordParameter1 + " " + pSlash + wordParameter2;
+        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
+        assertPreamblePresent(argMultimap, wordParameter1);
+        assertArgumentPresent(argMultimap, pSlash, wordParameter2);
+
+        // Preamble absent, word values.
+        argsString = pSlash + wordParameter2;
         argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
         assertPreambleEmpty(argMultimap);
-        assertArgumentPresent(argMultimap, pSlash, "Argument value");
+        assertArgumentPresent(argMultimap, pSlash, wordParameter2);
 
+        // Preamble present, sentence values.
+        argsString = sentenceParameter1 + " " + pSlash + sentenceParameter2;
+        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
+        assertPreamblePresent(argMultimap, sentenceParameter1);
+        assertArgumentPresent(argMultimap, pSlash, sentenceParameter2);
+
+        // Preamble absent, sentence values.
+        argsString = pSlash + sentenceParameter2;
+        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
+        assertPreambleEmpty(argMultimap);
+        assertArgumentPresent(argMultimap, pSlash, sentenceParameter2);
     }
 
     @Test
-    public void tokenize_multipleArguments() {
-        // Only two arguments are present
-        String argsString = "SomePreambleString -t dashT-Value p/pSlash value";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertPreamblePresent(argMultimap, "SomePreambleString");
-        assertArgumentPresent(argMultimap, pSlash, "pSlash value");
-        assertArgumentPresent(argMultimap, dashT, "dashT-Value");
-        assertArgumentAbsent(argMultimap, hatQ);
+    public void tokenize_multipleArguments() throws ParseException {
+        // Not all expected prefixes are present
+        String argsString = wordParameter1 + " " + pSlash + wordParameter2;
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dSlash);
+        assertPreamblePresent(argMultimap, wordParameter1);
+        assertArgumentPresent(argMultimap, pSlash, wordParameter2);
 
-        // All three arguments are present
-        argsString = "Different Preamble String ^Q111 -t dashT-Value p/pSlash value";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertPreamblePresent(argMultimap, "Different Preamble String");
-        assertArgumentPresent(argMultimap, pSlash, "pSlash value");
-        assertArgumentPresent(argMultimap, dashT, "dashT-Value");
-        assertArgumentPresent(argMultimap, hatQ, "111");
+        // All expected prefixes present
+        argsString = pSlash + wordParameter2 + " " + wordSlash + sentenceParameter1;
+        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dSlash, wordSlash);
+        assertPreambleEmpty(argMultimap);
+        assertArgumentPresent(argMultimap, pSlash, wordParameter2);
+        assertArgumentPresent(argMultimap, wordSlash, sentenceParameter1);
 
         /* Also covers: Reusing of the tokenizer multiple times */
 
         // Reuse tokenizer on an empty string to ensure ArgumentMultimap is correctly reset
         // (i.e. no stale values from the previous tokenizing remain)
         argsString = "";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
         assertPreambleEmpty(argMultimap);
         assertArgumentAbsent(argMultimap, pSlash);
-
-        /* Also covers: testing for prefixes not specified as a prefix */
-
-        // Prefixes not previously given to the tokenizer should not return any values
-        argsString = unknownPrefix + "some value";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertArgumentAbsent(argMultimap, unknownPrefix);
-        assertPreamblePresent(argMultimap, argsString); // Unknown prefix is taken as part of preamble
     }
 
     @Test
-    public void tokenize_multipleArgumentsWithRepeats() {
+    public void tokenize_multipleArgumentsWithRepeats() throws ParseException {
         // Two arguments repeated, some have empty values
-        String argsString = "SomePreambleString -t dashT-Value ^Q ^Q -t another dashT value p/ pSlash value -t";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertPreamblePresent(argMultimap, "SomePreambleString");
-        assertArgumentPresent(argMultimap, pSlash, "pSlash value");
-        assertArgumentPresent(argMultimap, dashT, "dashT-Value", "another dashT value", "");
-        assertArgumentPresent(argMultimap, hatQ, "", "");
+        String argsString = wordParameter1 + " " + pSlash + " " + pSlash
+                + wordParameter2 + " " + dSlash + sentenceParameter1 + " " + dSlash;
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dSlash);
+        assertPreamblePresent(argMultimap, wordParameter1);
+        assertArgumentPresent(argMultimap, pSlash, "", wordParameter2);
+        assertArgumentPresent(argMultimap, dSlash, sentenceParameter1, "");
     }
 
     @Test
-    public void tokenize_multipleArgumentsJoined() {
-        String argsString = "SomePreambleStringp/ pSlash joined-tjoined -t not joined^Qjoined";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertPreamblePresent(argMultimap, "SomePreambleStringp/ pSlash joined-tjoined");
-        assertArgumentAbsent(argMultimap, pSlash);
-        assertArgumentPresent(argMultimap, dashT, "not joined^Qjoined");
-        assertArgumentAbsent(argMultimap, hatQ);
+    public void tokenize_paddedSpaces() throws ParseException {
+        // Parameters with leading or trailing whitespace should be trimmed
+        String argsString = wordParameter1 + "  " + pSlash + " " + sentenceParameter2 + " ";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
+        assertPreamblePresent(argMultimap, wordParameter1);
+        assertArgumentPresent(argMultimap, pSlash, sentenceParameter2);
+    }
+
+    @Test
+    public void tokenize_unexpectedPrefixes_throwsParseException() throws ParseException {
+        // Unexpected single character prefix
+        String argsString1 = wordParameter1 + "  " + pSlash + " " + sentenceParameter2 + " ";
+        assertThrows(ParseException.class, () -> ArgumentTokenizer.tokenize(argsString1, dSlash));
+
+        // Unexpected multiple character prefix
+        String argsString2 = wordParameter1 + "  " + wordSlash + " " + sentenceParameter2 + " ";
+        assertThrows(ParseException.class, () -> ArgumentTokenizer.tokenize(argsString2, dSlash));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -11,13 +11,12 @@ import seedu.address.logic.parser.exceptions.ParseException;
 
 public class ArgumentTokenizerTest {
 
-    //private final Prefix unknownPrefix = new Prefix("--u");
     private final Prefix pSlash = new Prefix("p/");
     private final Prefix dSlash = new Prefix("d/");
     private final Prefix wordSlash = new Prefix("word/");
 
     private final String wordParameter1 = "Argument";
-    private final String wordParameter2 = "Argument";
+    private final String wordParameter2 = "Value";
     private final String sentenceParameter1 = "Argument value with spaces";
     private final String sentenceParameter2 = "Another argument value";
 

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -61,7 +61,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "0 " + NAME_DESC_BAGEL, MESSAGE_INVALID_COUNT_INDEX);
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string ", MESSAGE_INVALID_COUNT_INDEX);
+        assertParseFailure(parser, "1 some random string " + NAME_DESC_BAGEL, MESSAGE_INVALID_COUNT_INDEX);
 
         // empty preamble
         assertParseFailure(parser, NAME_DESC_BAGEL, MESSAGE_INVALID_COUNT_INDEX);

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -56,15 +56,15 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5 n/t" + NAME_DESC_BAGEL, MESSAGE_INVALID_COUNT_INDEX);
+        assertParseFailure(parser, "-5 " + NAME_DESC_BAGEL, MESSAGE_INVALID_COUNT_INDEX);
         // zero index
-        assertParseFailure(parser, "0 n/t" + NAME_DESC_BAGEL, MESSAGE_INVALID_COUNT_INDEX);
+        assertParseFailure(parser, "0 " + NAME_DESC_BAGEL, MESSAGE_INVALID_COUNT_INDEX);
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string n/t", MESSAGE_INVALID_COUNT_INDEX);
+        assertParseFailure(parser, "1 some random string ", MESSAGE_INVALID_COUNT_INDEX);
 
-        // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ string n/t", MESSAGE_INVALID_COUNT_INDEX);
+        // empty preamble
+        assertParseFailure(parser, NAME_DESC_BAGEL, MESSAGE_INVALID_COUNT_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -94,13 +94,13 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_negativeIdArgs_throwsParseException() {
-        assertParseFailure(parser, PREFIX_ID + INVALID_ID_NEGATIVE_NUMBER, String.format(
+        assertParseFailure(parser, INVALID_ID_NEGATIVE_NUMBER, String.format(
                 MESSAGE_INVALID_ID_LENGTH_AND_SIGN, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_notDigitsInArg_throwsParseException() {
-        assertParseFailure(parser, PREFIX_ID + INVALID_ID_LETTER, String.format(
+        assertParseFailure(parser, INVALID_ID_LETTER, String.format(
                 MESSAGE_INVALID_ID_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -13,7 +13,6 @@ import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_BAKED;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BAGEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_DONUT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BAKED;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalItems.BAGEL;

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -186,7 +186,7 @@ public class ParserUtilTest {
         // Negative integer
         assertThrows(ParseException.class, () -> ParserUtil.parseCount(INVALID_COUNT_NEGATIVE));
         // Large integer
-        String largeString = String.format("%d", (long)Integer.MAX_VALUE + 1);
+        String largeString = String.format("%d", (long) Integer.MAX_VALUE + 1);
         assertThrows(ParseException.class, () -> ParserUtil.parseCount(largeString));
         // Not an integer
         assertThrows(ParseException.class, () -> ParserUtil.parseCount(INVALID_COUNT_FLOAT));


### PR DESCRIPTION
Fixes #191 .

`ArgumentTokenizer` should attempt to detect all possible prefixes. If it detects a prefix that is not in its list of expected prefixes, it will throw an appropriate `ParseException`.

Misc Edits:
* Move @wangpeialex's equivalence partition tests from `AddToOrderCommandParserTest` to `ParserUtilTest`, where it is more appropriate.